### PR TITLE
Wait for packets to be accepted before returning from writev

### DIFF
--- a/lib/netif.ml
+++ b/lib/netif.ml
@@ -455,7 +455,7 @@ let writev nf pages =
          lwt rest_th = xmit other_pages in
          (* All fragments are now written, we can now notify the backend *)
          Lwt_ring.Front.push nf.t.tx_client (notify nf.t);
-         return ()
+         join rest_th
     )
 
 let wait_for_plug nf =


### PR DESCRIPTION
Without this, the caller has no way to know when it's safe to reuse the
buffer. This also works around this problem:

http://lists.xenproject.org/archives/html/xen-users/2014-07/msg00067.html
