### PR TITLE
Revert "Wait for packets to be accepted before returning from writev"

### DIFF
--- a/lib/netif.ml
+++ b/lib/netif.ml
@@ -455,7 +455,7 @@ let writev nf pages =
          lwt rest_th = xmit other_pages in
          (* All fragments are now written, we can now notify the backend *)
          Lwt_ring.Front.push nf.t.tx_client (notify nf.t);
-         join rest_th
+         return ()
     )
 
 let wait_for_plug nf =


### PR DESCRIPTION
Linux dom0 and Xen have been patched to fix the underlying bug, and this work-around made things really slow.

This reverts commit aa5061b8ffdc2e34968e80ed745ffd77372fa358.
