### PR TITLE
Copy out-bound data into pre-shared pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,3 @@ language: c
 script: bash -ex .travis-ci.sh
 env:
   - OCAML_VERSION=4.01.0 OPAM_VERSION=1.1.0
-  - OCAML_VERSION=4.00.1 OPAM_VERSION=1.1.0

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+* When waiting for space in the transmit queue, we would sometimes fail to notice when
+  space became available.
+* Copy out-bound data into pre-shared pages for performance, security and simplicity.
+
 1.2.0 (2014-12-17):
 * Add profiling tracepoints and labels (#13).  Introduces a dependency on `mirage-profile`.
 * New `opam` file present in source repository for OPAM 1.2 workflow.

--- a/_tags
+++ b/_tags
@@ -26,3 +26,4 @@ true: annot, bin_annot
 <lib/*.ml{,i,y}>: pkg_xen-gnt
 # OASIS_STOP
 true: annot, bin_annot, debug, principal
+true: warn(A-27-32-34-37), strict_sequence


### PR DESCRIPTION
The original motivation for this is to make TLS support work. Currently, TLS copies the encrypted buffers into a large Io_page, and TCP then sends segment-sized Cstruct views of this buffer to the network. If any of these overlap a page boundary, the send will fail.

With this patch, TLS can send ordinary unaligned buffers to TCP (avoiding a copy). The copy now happens in Netif.

This some other advantages:

- It avoids splitting requests across multiple grants (before, we sent
  the IP header and payload in separate pages).
- It avoids the security problem of sharing unrelated data that happens
  to be in the same page. Now, netback will only ever see data
  explicitly sent to it.
- It allows the sender to reuse pages as soon as Netif.write returns.
  Before, the pages were queued and the application could change them
  even as netback was reading them. Behaviour should now be
  deterministic.
- It's faster (132 MB/s -> 181 MB/s for an x86_64 unikernel running
  under Xen in VirtualBox on my laptop).