### PR TITLE
Don't assume the first interface is meant when id can't be decoded.

### DIFF
--- a/lib/frontend.ml
+++ b/lib/frontend.ml
@@ -231,18 +231,10 @@ module Make(C: S.CONFIGURATION with type 'a io = 'a Lwt.t) = struct
     loop Activations.program_start
 
   let connect id =
-    (* If [id] is an integer, use it. Otherwise default to the first
-       available disk. *)
-    lwt id' =
-      let id = try Some (int_of_string id) with _ -> None in
-      match id with 
-      | Some id -> 
-        return (Some id)
-      | None -> 
-        C.enumerate ()
-        >>= function
-        | [] -> return None 
-        | hd::_ -> return (Some (int_of_string hd))
+    (* If [id] is an integer, use it. Otherwise, return an error message
+       which enumerates the available interfaces. *)
+    let id' =
+      try Some (int_of_string id) with _ -> None
     in
     match id' with
     | Some id' -> begin


### PR DESCRIPTION
Previously, `connect` would assume that the first available interface
was the correct one to use if the `id` parameter couldn't be matched.
This could lead to information leakage or other unexpected (and
difficult to debug) behaviors.  Instead, don't assume this and return an
error if the id doesn't make sense.

Signed-off-by: Mindy Preston <mindy.preston@docker.com>