### PR TITLE
Log exceptions from the listen callback

### DIFF
--- a/lib/frontend.ml
+++ b/lib/frontend.ml
@@ -222,7 +222,12 @@ module Make(C: S.CONFIGURATION with type 'a io = 'a Lwt.t) = struct
           assert (!next = Cstruct.len data);
           Lwt.async (fun () ->
             Stats.rx nf.stats (Int64.of_int (Cstruct.len data));
-            fn data
+            Lwt.catch (fun () -> fn data)
+              (fun ex ->
+                 Log.err (fun f -> f "uncaught exception from listen callback while handling frame:@\n%a@\nException: @[%s@]"
+                             S.pp_frame data (Printexc.to_string ex));
+                 Lwt.return ()
+              )
           )
     )
 

--- a/lib/s.ml
+++ b/lib/s.ml
@@ -34,6 +34,12 @@ type frontend_configuration = {
   feature_requests: Features.t;
 } [@@deriving sexp]
 
+(* Should probably move this to Cstruct. *)
+let pp_frame fmt x =
+  let b = Buffer.create (Cstruct.len x * 3) in
+  Cstruct.hexdump_to_buffer b x;
+  Format.pp_print_string fmt (Buffer.contents b)
+
 module type CONFIGURATION = sig
 
   type 'a io


### PR DESCRIPTION
Since version 1.5 we've been passing exceptions to the user's Lwt
exception handler rather than printing to the console. It seems that
several users decided to stay with 1.4 rather than configure a handler.
This patch uses the new logging support to log an error and continue.
In addition, it also dumps out the frame that caused the crash.

Closes #39

Note: we should add similar handlers further up the stack (e.g. in tcpip), since they can provide more context to the user (e.g. identifying the details of the TCP connection rather than just the single frame that triggered the problem). /cc @yomimono 