### PR TITLE
refer to mirage module types modules by new name

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -87,5 +87,5 @@
 
 0.9.0 (2013-12-10):
 * Add Travis CI scripts.
-* Adapt to V1.NETWORK from mirage-types-0.5.0.
+* Adapt to Mirage_types.NETWORK from mirage-types-0.5.0.
 * Initial release based on mirage-platform-0.9.8 Netif.

--- a/lib/stats.ml
+++ b/lib/stats.ml
@@ -17,7 +17,7 @@
 
 open Mirage_net
 
-(* XXX: should move to mirage-net (V1.Stats) *)
+(* XXX: should move to mirage-net (Mirage_types.Stats) *)
 
 let create () = { rx_pkts=0l; rx_bytes=0L; tx_pkts=0l; tx_bytes=0L }
 


### PR DESCRIPTION
V1 is now Mirage_types, and V1_LWT is now Mirage_types_lwt, as of MirageOS version 3.0.0.