### PR TITLE
topkg: manually specify the name as the auto-detect fails

### DIFF
--- a/pkg/pkg.ml
+++ b/pkg/pkg.ml
@@ -1,3 +1,7 @@
 #!/usr/bin/env ocaml
 #use "topfind"
-#require "topkg-jbuilder.auto"
+#require "topkg-jbuilder"
+
+let _ =
+Topkg_jbuilder.describe ~name:"mirage-net-xen" ()
+


### PR DESCRIPTION
Signed-off-by: David Scott <dave@recoil.org>