### PR TITLE
Fix build errors

### DIFF
--- a/lib/rX.ml
+++ b/lib/rX.ml
@@ -17,6 +17,8 @@
 open Result
 open Sexplib.Std
 
+[@@@ocaml.warning "-32"]  (* cstruct ppx generates unused values *)
+
 module Request = struct
   type t = {
     id: int;

--- a/lib/tX.ml
+++ b/lib/tX.ml
@@ -16,6 +16,8 @@
  *)
 open Result
 
+[@@@ocaml.warning "-32"]  (* cstruct ppx generates unused values *)
+
 module Request = struct
   type error = { impossible : 'a. 'a }
 


### PR DESCRIPTION
The cstruct ppx generates unused values (e.g. `hexdump_req`). This prevents the project from building with the Makefile (which makes warnings fatal).