### PR TITLE
Support client-initiated shutdown

### DIFF
--- a/lib/backend.ml
+++ b/lib/backend.ml
@@ -25,6 +25,34 @@ module Log = (val Logs.src_log src : Logs.LOG)
 
 let return = Lwt.return
 
+module Cleanup : sig
+  type t
+  (** A stack of (cleanup) actions to perform.
+      This is a bit like [Lwt_switch], but ensures things happen in order. *)
+
+  val create : unit -> t
+
+  val push : t -> (unit -> unit Lwt.t) -> unit
+  (** [push t fn] adds [fn] to the stack of clean-up operations to perform. *)
+
+  val perform : t -> unit Lwt.t
+  (** [perform t] pops and performs actions from the stack until it is empty. *)
+end = struct
+  type t = (unit -> unit Lwt.t) Stack.t
+
+  let create = Stack.create
+
+  let push t fn = Stack.push fn t
+
+  let rec perform t =
+    if Stack.is_empty t then Lwt.return_unit
+    else (
+      let fn = Stack.pop t in
+      fn () >>= fun () ->
+      perform t
+    )
+end
+
 module Make(C: S.CONFIGURATION with type 'a io = 'a Lwt.t) = struct
   exception Netback_shutdown
 
@@ -53,18 +81,20 @@ module Make(C: S.CONFIGURATION with type 'a io = 'a Lwt.t) = struct
 
   let create ~switch ~domid ~device_id =
     let id = `Server (domid, device_id) in
-    Lwt_switch.add_hook (Some switch) (fun () -> C.disconnect_backend id);
+    let cleanup = Cleanup.create () in
+    Lwt_switch.add_hook (Some switch) (fun () -> Cleanup.perform cleanup);
+    Cleanup.push cleanup (fun () -> C.disconnect_backend id);
     C.read_mac id >>= fun mac ->
     C.init_backend id Features.supported >>= fun backend_configuration ->
     let frontend_id = backend_configuration.S.frontend_id in
     C.read_frontend_configuration id >>= fun f ->
     let channel = Eventchn.bind_interdomain h frontend_id (int_of_string f.S.event_channel) in
-    Lwt_switch.add_hook (Some switch) (fun () -> Eventchn.unbind h channel; return ());
+    Cleanup.push cleanup (fun () -> Eventchn.unbind h channel; return ());
     (* Note: TX and RX are from netfront's point of view (e.g. we receive on TX). *)
     let from_netfront =
       let tx_gnt = {Gnt.Gnttab.domid = frontend_id; ref = Int32.to_int f.S.tx_ring_ref} in
       let mapping = Gnt.Gnttab.map_exn gnttab tx_gnt true in
-      Lwt_switch.add_hook (Some switch) (fun () -> Gnt.Gnttab.unmap_exn gnttab mapping; return ());
+      Cleanup.push cleanup (fun () -> Gnt.Gnttab.unmap_exn gnttab mapping; return ());
       let buf = Gnt.Gnttab.Local_mapping.to_buf mapping |> Io_page.to_cstruct in
       let sring = Ring.Rpc.of_buf_no_init ~buf ~idx_size:TX.total_size
         ~name:("Netif.Backend.TX." ^ backend_configuration.S.backend) in
@@ -72,7 +102,7 @@ module Make(C: S.CONFIGURATION with type 'a io = 'a Lwt.t) = struct
     let to_netfront =
       let rx_gnt = {Gnt.Gnttab.domid = frontend_id; ref = Int32.to_int f.S.rx_ring_ref} in
       let mapping = Gnt.Gnttab.map_exn gnttab rx_gnt true in
-      Lwt_switch.add_hook (Some switch) (fun () -> Gnt.Gnttab.unmap_exn gnttab mapping; return ());
+      Cleanup.push cleanup (fun () -> Gnt.Gnttab.unmap_exn gnttab mapping; return ());
       let buf = Gnt.Gnttab.Local_mapping.to_buf mapping |> Io_page.to_cstruct in
       let sring = Ring.Rpc.of_buf_no_init ~buf ~idx_size:RX.total_size
         ~name:("Netif.Backend.RX." ^ backend_configuration.S.backend) in
@@ -88,12 +118,16 @@ module Make(C: S.CONFIGURATION with type 'a io = 'a Lwt.t) = struct
       to_netfront = Some to_netfront; from_netfront = Some from_netfront; rx_reqs;
       get_free_mutex; write_mutex;
       stats; mac; } in
-    Lwt_switch.add_hook (Some switch) (fun () ->
+    Cleanup.push cleanup (fun () ->
       t.to_netfront <- None;
       t.from_netfront <- None;
       return ()
     );
-    Lwt.async (fun () -> C.wait_for_backend_closing id >>= fun () -> Lwt_switch.turn_off switch);
+    Lwt.async (fun () ->
+        C.wait_for_frontend_closing id >>= fun () ->
+        Log.info (fun f -> f "Frontend asked to close network device dom:%d/vif:%d" domid device_id);
+        Lwt_switch.turn_off switch
+      );
     return t
 
   let make ~domid ~device_id =


### PR DESCRIPTION
Commit cc77a1a noted "Not sure whether we should be watching the frontend or backend state, but this works with QubesOS at least."

It seems that if we want to allow Qubes guests to shut down their own interfaces then we need to be watching the frontend instead (or maybe as well).

This is important for HVM guests, as the stub domain tries to shut down the interface while booting. For example, if you try to install Debian 9 it will hang after selecting the install option from the boot menu.
The guest's stub-domain log shows e.g.

    close network: backend at /local/domain/2/backend/vif/11/0

as the last output in this case.

This needs a bit more testing, and maybe some better logging (killing a VM in Qubes causes the firewall to log a warning about a XenStore permission problem), but people might like to pin `netchannel` to this to see if allows HVM guests to work.

/cc @yomimono 

Fixes #61.