### PR TITLE
Netback should not initialise the shared rings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/ma
 script: bash -ex ./.travis-docker.sh
 env:
   global:
-  - PINS="netchannel:. mirage-net-xen:."
+  - PINS="netchannel:. mirage-net-xen:. shared-memory-ring"
   - PACKAGE="mirage-net-xen"
   matrix:
   - DISTRO="ubuntu-16.04" OCAML_VERSION="4.03.0"

--- a/lib/backend.ml
+++ b/lib/backend.ml
@@ -66,7 +66,7 @@ module Make(C: S.CONFIGURATION with type 'a io = 'a Lwt.t) = struct
       let mapping = Gnt.Gnttab.map_exn gnttab tx_gnt true in
       Lwt_switch.add_hook (Some switch) (fun () -> Gnt.Gnttab.unmap_exn gnttab mapping; return ());
       let buf = Gnt.Gnttab.Local_mapping.to_buf mapping |> Io_page.to_cstruct in
-      let sring = Ring.Rpc.of_buf ~buf ~idx_size:TX.total_size
+      let sring = Ring.Rpc.of_buf_no_init ~buf ~idx_size:TX.total_size
         ~name:("Netif.Backend.TX." ^ backend_configuration.S.backend) in
       Ring.Rpc.Back.init ~sring in
     let to_netfront =
@@ -74,7 +74,7 @@ module Make(C: S.CONFIGURATION with type 'a io = 'a Lwt.t) = struct
       let mapping = Gnt.Gnttab.map_exn gnttab rx_gnt true in
       Lwt_switch.add_hook (Some switch) (fun () -> Gnt.Gnttab.unmap_exn gnttab mapping; return ());
       let buf = Gnt.Gnttab.Local_mapping.to_buf mapping |> Io_page.to_cstruct in
-      let sring = Ring.Rpc.of_buf ~buf ~idx_size:RX.total_size
+      let sring = Ring.Rpc.of_buf_no_init ~buf ~idx_size:RX.total_size
         ~name:("Netif.Backend.RX." ^ backend_configuration.S.backend) in
       Ring.Rpc.Back.init ~sring in
     let stats = Stats.create () in


### PR DESCRIPTION
It seems that netfront is responsible for this. If netback does it too, it will overwrite the client's data.

In particular, this prevented Qubes disposable Linux VMs from working when restored. They would populate the ring with RX pages before handing it to the Mirage netback, which would then reinitialise the ring and lose them all. It would then wait forever for Linux to provide it with some pages to write to.

At least, this is my guess. The protocol does not appear to be documented anywhere.

This depends on https://github.com/mirage/shared-memory-ring/pull/36.