### PR TITLE
Fix opam build rules

### DIFF
--- a/mirage-net-xen.opam
+++ b/mirage-net-xen.opam
@@ -6,7 +6,7 @@ bug-reports:   "https://github.com/mirage/mirage-net-xen/issues"
 dev-repo:      "https://github.com/mirage/mirage-net-xen.git"
 doc:           "https://mirage.github.io/mirage-net-xen"
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-n" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 

--- a/netchannel.opam
+++ b/netchannel.opam
@@ -6,7 +6,7 @@ bug-reports:   "https://github.com/mirage/mirage-net-xen/issues"
 dev-repo:      "https://github.com/mirage/mirage-net-xen.git"
 doc:           "https://mirage.github.io/mirage-net-xen"
 build: [
-  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "subst" "-n" name] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 


### PR DESCRIPTION
Pass `-n name` to `jbuilder subst`.

Was failing with:

    # Error: cannot determine name automatically.
    # You must pass a [--name] command line argument.