### PR TITLE
since d27f45a5 we need shared-memory-ring >= 3.0.0 in order to access…Ring.Rpc.of_buf_no_init

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,10 @@ install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/ma
 script: bash -ex ./.travis-docker.sh
 env:
   global:
-  - PINS="netchannel:. mirage-net-xen:. shared-memory-ring"
+  - PINS="netchannel:. mirage-net-xen:."
   - PACKAGE="mirage-net-xen"
   matrix:
   - DISTRO="ubuntu-16.04" OCAML_VERSION="4.03.0"
   - DISTRO="alpine-3.5" OCAML_VERSION="4.04.0"
+  - DISTRO="ubuntu-16.04" OCAML_VERSION="4.04.2"
+  - DISTRO="ubuntu-16.04" OCAML_VERSION="4.05.0"

--- a/netchannel.opam
+++ b/netchannel.opam
@@ -23,7 +23,7 @@ depends: [
   "mirage-xen" {>= "1.1.0"}
   "ipaddr" {>= "1.0.0"}
   "mirage-profile" {>="0.3"}
-  "shared-memory-ring" {>="1.1.1"}
+  "shared-memory-ring" {>="3.0.0"}
   "sexplib" {>= "113.01.00"}
   "result"
   "logs" {>= "0.5.0"}


### PR DESCRIPTION
see also https://github.com/ocaml/opam-repository/pull/11577 for a fix of netchannel in opam-repository