### PR TITLE
when getting pages from the pool, zero the buffer before calling fill…

### DIFF
--- a/lib/backend.ml
+++ b/lib/backend.ml
@@ -249,6 +249,7 @@ module Make(C: S.CONFIGURATION with type 'a io = 'a Lwt.t) = struct
                let gnt = {Gnt.Gnttab.domid = t.frontend_id; ref = Int32.to_int r.RX.Request.gref} in
                let mapping = Gnt.Gnttab.map_exn gnttab gnt true in
                let dst = Gnt.Gnttab.Local_mapping.to_buf mapping |> Io_page.to_cstruct in
+               Cstruct.memset dst 0;
                let len = fillf dst in
                if len > size then failwith "length exceeds total size" ;
                Gnt.Gnttab.unmap_exn gnttab mapping;

--- a/lib/frontend.ml
+++ b/lib/frontend.ml
@@ -309,6 +309,7 @@ module Make(C: S.CONFIGURATION with type 'a io = 'a Lwt.t) = struct
    * The buffer's data must fit in a single block. *)
   let write_already_locked nf ~size fillf =
     Shared_page_pool.use nf.t.tx_pool (fun ~id gref shared_block ->
+        Cstruct.memset shared_block 0;
         let len = fillf shared_block in
         if len > size then failwith "length exceeds size" ;
         Stats.tx nf.t.stats (Int64.of_int len);


### PR DESCRIPTION
… function

`Shared_page_pool.use` makes no guarantee about the memory being zeroed
before use.  Since `write` *does* make such a guarantee, call
`Cstruct.memset` to zero out the buffer before invoking the fill
function.