### PR TITLE
Use hard-coded MAC for backend devices

### DIFF
--- a/lib/backend.mli
+++ b/lib/backend.mli
@@ -19,4 +19,6 @@ module Make(C: S.CONFIGURATION with type 'a io = 'a Lwt.t) : sig
   include Mirage_net_lwt.S
   val make: domid:int -> device_id:int -> t Lwt.t
   (** [make ~domid ~device_id] connects a backend connecting to [domid] *)
+
+  val frontend_mac : t -> Macaddr.t
 end

--- a/lib/frontend.ml
+++ b/lib/frontend.ml
@@ -103,7 +103,7 @@ module Make(C: S.CONFIGURATION with type 'a io = 'a Lwt.t) = struct
     let features = backend_conf.S.features_available in
     Log.info Features.(fun f -> f " sg:%b gso_tcpv4:%b rx_copy:%b rx_flip:%b smart_poll:%b"
       features.sg features.gso_tcpv4 features.rx_copy features.rx_flip features.smart_poll);
-    C.read_mac id >>= fun mac ->
+    C.read_frontend_mac id >>= fun mac ->
     Log.info (fun f -> f "MAC: %s" (Macaddr.to_string mac));
     (* Allocate a transmit and receive ring, and event channel *)
     create_rx (vif_id, backend_id)

--- a/lib/s.ml
+++ b/lib/s.ml
@@ -38,7 +38,8 @@ module type CONFIGURATION = sig
 
   type 'a io
 
-  val read_mac: id -> Macaddr.t io
+  val read_frontend_mac: id -> Macaddr.t io
+  val read_backend_mac: id -> Macaddr.t io
 
   val read_mtu: id -> int io
 

--- a/lib/xenstore.ml
+++ b/lib/xenstore.ml
@@ -64,7 +64,7 @@ module Make(Xs: Xs_client_lwt.S) = struct
   | `Server (domid, devid) ->
     return (Printf.sprintf "backend/vif/%d/%d" domid devid)
 
-  let read_mac id =
+  let read_frontend_mac id =
     frontend id
     >>= fun frontend ->
     Xs.make ()
@@ -78,6 +78,12 @@ module Make(Xs: Xs_client_lwt.S) = struct
       Log.info (fun f -> f "%s: no configured MAC (error: %s), using %a"
         (Sexplib.Sexp.to_string (S.sexp_of_id id)) msg Macaddr.pp m);
       return m
+
+  (* Curiously, libxl writes the frontend MAC to both the frontend and
+     backend directories. The convention seems to be to use this as the
+     backend MAC. See: https://github.com/QubesOS/qubes-issues/issues/5013 *)
+  let backend_mac = Macaddr.of_string_exn "fe:ff:ff:ff:ff:ff"
+  let read_backend_mac _ = return backend_mac
 
   let read_mtu _id = return 1514 (* TODO *)
 


### PR DESCRIPTION
We previously always used the frontend's "mac" from XenStore for the MAC address, even for backend devices.

There is a separate "mac" key under the backend directory, but libxl just writes a copy of the frontend MAC there too. The convention seems to be to use `fe:ff:ff:ff:ff:ff` as the backend MAC.

This commit changes the `CONFIGURATION` signature to provide both `read_frontend_mac` and `read_backend_mac`, and changes the XenStore implementation to return `fe:ff:ff:ff:ff:ff` for backends.

See: https://github.com/QubesOS/qubes-issues/issues/5013

/cc @djs55