### PR TITLE
Cope with frontend going directly to Closed state

### DIFF
--- a/lib/xenstore.ml
+++ b/lib/xenstore.ml
@@ -298,8 +298,9 @@ module Make(Xs: Xs_client_lwt.S) = struct
              Xs.read h (path / "state")
           )
           (fun state ->
-             if OS.Device_state.of_string state = OS.Device_state.Closing then return ()
-             else Lwt.fail Xs_protocol.Eagain
+             match OS.Device_state.of_string state with
+             | OS.Device_state.Closing | Closed -> return ()
+             | _ -> Lwt.fail Xs_protocol.Eagain
           )
           (fun ex ->
              Log.warn (fun f -> f "Error reading device state at %S: %a" path Fmt.exn ex);


### PR DESCRIPTION
When you do `qvm-prefs foo netvm None`, the domain's frontend state goes directly to `Closed`, whereas we expected it to go first to `Closing` and wait there for us to confirm.

See https://github.com/mirage/qubes-mirage-firewall/issues/59

This doesn't actually fix the problem, but it's probably part of the fix.