### PR TITLE
remove colons in log prefixes

### DIFF
--- a/lib/backend.ml
+++ b/lib/backend.ml
@@ -22,7 +22,7 @@ open Mirage_net
 module Gntref = OS.Xen.Gntref
 module Import = OS.Xen.Import
 
-let src = Logs.Src.create "net-xen:backend" ~doc:"Mirage's Xen netback"
+let src = Logs.Src.create "net-xen backend" ~doc:"Mirage's Xen netback"
 module Log = (val Logs.src_log src : Logs.LOG)
 
 let return = Lwt.return

--- a/lib/frontend.ml
+++ b/lib/frontend.ml
@@ -21,7 +21,7 @@ open Mirage_net
 module Gntref = OS.Xen.Gntref
 module Export = OS.Xen.Export
 
-let src = Logs.Src.create "net-xen:frontend" ~doc:"Mirage's Xen netfront"
+let src = Logs.Src.create "net-xen frontend" ~doc:"Mirage's Xen netfront"
 module Log = (val Logs.src_log src : Logs.LOG)
 
 let return = Lwt.return

--- a/lib/xenstore.ml
+++ b/lib/xenstore.ml
@@ -15,7 +15,7 @@
  *)
 open Lwt
 
-let src = Logs.Src.create "net-xen:xenstore" ~doc:"mirage-net-xen's XenStore client"
+let src = Logs.Src.create "net-xen xenstore" ~doc:"mirage-net-xen's XenStore client"
 module Log = (val Logs.src_log src : Logs.LOG)
 
 let (/) a b =


### PR DESCRIPTION
`mirage configure -l` expects colons to separate the log prefixes from
their levels.  If the prefixes have colons in them, they can't be
specified.  Change them to spaces, which are handled properly.

Co-authored-by: linse <sschirme@gmail.com>