### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/mirage-net-xen.opam
+++ b/mirage-net-xen.opam
@@ -12,7 +12,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.04.0"}
-  "dune"  {build & >= "1.0"}
+  "dune"  {>= "1.0"}
   "cstruct" {>= "3.0.0"}
   "lwt" {>= "2.4.3"}
   "mirage-net-lwt" {>= "2.0.0"}

--- a/netchannel.opam
+++ b/netchannel.opam
@@ -12,7 +12,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.04.0"}
-  "dune"  {build & >= "1.0"}
+  "dune"  {>= "1.0"}
   "cstruct" {>= "3.0.0"}
   "ppx_sexp_conv"
   "ppx_cstruct"


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.