### PR TITLE
caceb7142fdcd192aaad4b5a32ffb1566521f392 removed colons from log sources

### DIFF
--- a/lib/xenstore.ml
+++ b/lib/xenstore.ml
@@ -17,7 +17,7 @@ open Lwt
 
 module OS = Os_xen
 
-let src = Logs.Src.create "net-xen:xenstore" ~doc:"mirage-net-xen's XenStore client"
+let src = Logs.Src.create "net-xen xenstore" ~doc:"mirage-net-xen's XenStore client"
 module Log = (val Logs.src_log src : Logs.LOG)
 
 let (/) a b =


### PR DESCRIPTION
(mirage command line uses colon as separator between source and level), the
merge commit 6a4fd2a470e9f7502754c0af83b4594f30a7e744 reintroduced a colon

this commit removes the colon again