### PR TITLE
In MirageOS / mirage-net, the MTU is defined as the Ethernet payload

### DIFF
--- a/lib/backend.ml
+++ b/lib/backend.ml
@@ -254,7 +254,7 @@ module Make(C: S.CONFIGURATION) = struct
                let mapping = Import.map_exn gnt ~writable:true in
                let dst = Import.Local_mapping.to_buf mapping |> Io_page.to_cstruct in
                Cstruct.memset dst 0;
-               let len = fillf dst in
+               let len = fillf (Cstruct.sub dst 0 (t.mtu + 14)) in
                Import.Local_mapping.unmap_exn mapping;
                if len > size then failwith "length exceeds total size" ;
                let slot =

--- a/lib/backend.ml
+++ b/lib/backend.ml
@@ -254,7 +254,7 @@ module Make(C: S.CONFIGURATION) = struct
                let mapping = Import.map_exn gnt ~writable:true in
                let dst = Import.Local_mapping.to_buf mapping |> Io_page.to_cstruct in
                Cstruct.memset dst 0;
-               let len = fillf (Cstruct.sub dst 0 (t.mtu + 14)) in
+               let len = fillf (Cstruct.sub dst 0 size) in
                Import.Local_mapping.unmap_exn mapping;
                if len > size then failwith "length exceeds total size" ;
                let slot =

--- a/lib/frontend.ml
+++ b/lib/frontend.ml
@@ -309,7 +309,7 @@ module Make(C: S.CONFIGURATION) = struct
   let write_already_locked nf ~size fillf =
     Shared_page_pool.use nf.t.tx_pool (fun ~id gref shared_block ->
         Cstruct.memset shared_block 0;
-        let len = fillf shared_block in
+        let len = fillf (Cstruct.sub shared_block 0 (nf.t.mtu + 14)) in
         if len > size then failwith "length exceeds size" ;
         Stats.tx nf.t.stats (Int64.of_int len);
         let request = { TX.Request.
@@ -339,12 +339,12 @@ module Make(C: S.CONFIGURATION) = struct
     Lwt_mutex.with_lock nf.t.tx_mutex
       (fun () ->
          Lwt_ring.Front.wait_for_free nf.t.tx_client numneeded >>= fun () ->
-         match numneeded with
-         | 0 -> return (return ())
-         | 1 ->
+         if size = 0 then
+           return (return ())
+         else if size <= nf.t.mtu + 14 then
            (* If there is only one block, then just write it normally *)
            write_already_locked nf ~size fillf
-         | n ->
+         else
            let datav = Cstruct.create size in
            let len = fillf datav in
            if len > size then failwith "length exceeds total size" ;
@@ -367,7 +367,7 @@ module Make(C: S.CONFIGURATION) = struct
                  xmit datav (n - 1)
                  >>= fun rest ->
                  return (next_th :: rest) in
-           xmit datav (n - 1)
+           xmit datav (numneeded - 1)
            >>= fun rest_th ->
            (* All fragments are now written, we can now notify the backend *)
            Lwt_ring.Front.push nf.t.tx_client (notify nf.t);

--- a/lib/xenstore.ml
+++ b/lib/xenstore.ml
@@ -83,7 +83,7 @@ module Make(Xs: Xs_client_lwt.S) = struct
   let backend_mac = Macaddr.of_string_exn "fe:ff:ff:ff:ff:ff"
   let read_backend_mac _ = return backend_mac
 
-  let read_mtu _id = return 1514 (* TODO *)
+  let read_mtu _id = return 1500 (* TODO *)
 
   let read_features side path =
     Xs.make ()


### PR DESCRIPTION
so in xenstore.ml, the `return 1514` was wrong (and fixed by 1500).

but I'm still not sure how networking on xen is supposed to work. what I understand from the code is that it takes full pages (4096 bytes), splits them into halves, and fills these as buffers. now, how is this related to the mtu?

the mirage stack, in contrast, respects whatever the mtu returns, and only ever transmits ethernet packets which are smaller than mtu (+ 14 byte ethernet header).

I'm not confident about the `numneeded` etc. code in frontend and backend, especially if it is > 1. what I can reason and understand about is ethernet packets up to 1514 bytes including the ethernet header. what I do not know is what should happen with bigger packets. any hints are welcome. how does xen handle them? should they be fragmented or not?

This should fix the immediate issue https://github.com/mirage/qubes-mirage-firewall/issues/111 if `netchannel` is pinned to this branch.