### PR TITLE
go to state closed and wait for ack before removing vif

### DIFF
--- a/lib/xenstore.ml
+++ b/lib/xenstore.ml
@@ -326,7 +326,7 @@ module Make(Xs: Xs_client_lwt.S) = struct
     >>= fun path ->
     Lwt.catch (fun () ->
         Xs.(immediate xsc (fun h -> write h (path / "state") Xen_os.Device_state.(to_string Closed))) >>= fun _ ->
-        wait_for_frontend_closing id >>= fun _ ->
+        wait_for_frontend_closing id >>= fun () ->
         Xs.(immediate xsc (fun h -> rm h path))
       )
       (fun ex ->

--- a/lib/xenstore.ml
+++ b/lib/xenstore.ml
@@ -325,6 +325,8 @@ module Make(Xs: Xs_client_lwt.S) = struct
     backend id
     >>= fun path ->
     Lwt.catch (fun () ->
+        Xs.(immediate xsc (fun h -> write h (path / "state") Xen_os.Device_state.(to_string Closed))) >>= fun _ ->
+        wait_for_frontend_closing id >>= fun _ ->
         Xs.(immediate xsc (fun h -> rm h path))
       )
       (fun ex ->


### PR DESCRIPTION
This PR is needed to change the state to closing and wait for the frontend to be ready before removing the vif. This should fix https://github.com/mirage/qubes-mirage-firewall/issues/157.