### PR TITLE
reuse some allocated pages to avoid allocation for each client packet

### DIFF
--- a/lib/frontend.ml
+++ b/lib/frontend.ml
@@ -136,7 +136,8 @@ module Make(C: S.CONFIGURATION) = struct
     C.read_mtu id >>= fun mtu ->
     return { vif_id; backend_id; tx_client; tx_gnt; tx_mutex; tx_pool;
              rx_gnt; rx_fring; rx_client; rx_map; rx_id = 0 ; stats;
-             evtchn; mac; mtu; backend; features; free_pages = [];
+             evtchn; mac; mtu; backend; features;
+             free_pages = Io_page.pages 128; (* Pre-allocate 128*4kB=512kB of free_pages*)
            }
 
   (** Set of active block devices *)
@@ -205,7 +206,7 @@ module Make(C: S.CONFIGURATION) = struct
       | Error (e, msgs) ->
           Log.err (fun f -> f "received error: %d" e);
           msgs |> Lwt_list.iter_s (fun msg ->
-            pop_rx_page nf msg.RX.Response.id >>= fun (_ : Io_page.t) ->
+            pop_rx_page nf msg.RX.Response.id >>= fun (page : Io_page.t) ->
             nf.free_pages <- page::nf.free_pages ;
             Lwt.return_unit
           )

--- a/lib/frontend.ml
+++ b/lib/frontend.ml
@@ -73,7 +73,7 @@ module Make(C: S.CONFIGURATION) = struct
     rx_map: (int, Gntref.t * Io_page.t) Hashtbl.t;
     rx_gnt: Gntref.t;
     mutable rx_id: Cstruct.uint16;
-    mutable free_pages: Io_page.t list;
+    mutable free_pages: Io_page.t list * int * int * int;
 
     evtchn: Xen_os.Eventchn.t;
     features: Features.t;
@@ -134,10 +134,15 @@ module Make(C: S.CONFIGURATION) = struct
     (* Register callback activation *)
     let backend = backend_conf.S.backend in
     C.read_mtu id >>= fun mtu ->
+    let n_pages = 64 in (* Default size for pre-allocated free pages *)
+    let pages = Io_page.get n_pages in
+    let start_address = Nativeint.to_int (Io_page.get_addr pages) in
+    (* With this formula, the semantic is that page are within [start_address, end_address[ *)
+    let end_address = start_address + n_pages * Io_page.page_size in
     return { vif_id; backend_id; tx_client; tx_gnt; tx_mutex; tx_pool;
              rx_gnt; rx_fring; rx_client; rx_map; rx_id = 0 ; stats;
              evtchn; mac; mtu; backend; features;
-             free_pages = Io_page.pages 128; (* Pre-allocate 128*4kB=512kB of free_pages*)
+             free_pages = (Io_page.to_pages (Io_page.get n_pages), n_pages, start_address, end_address); (* Pre-allocate 64*4kB=256kB of free_pages*)
            }
 
   (** Set of active block devices *)
@@ -147,19 +152,40 @@ module Make(C: S.CONFIGURATION) = struct
     Xen_os.Eventchn.notify h nf.evtchn
 
   let take_pages t n =
-    let rec inner t n acc =
-      if n==0 then acc
-      else (
-        match t.free_pages with
-        | hd::tl ->
-          t.free_pages <- tl;
-          inner t (n-1) (hd::acc)
-        | [] ->
-          let pages = Io_page.pages n in
-          List.append pages acc
-      )
+    (* returns the first n elements of l, and l without them, assumes than l is long enough *)
+    let rec split_list l n acc = match n, l with
+        | 0, _ -> acc, l
+        | n, [] -> assert false (* We assume l is long enough *)
+        | n, hd::tl -> split_list tl (n-1) (hd::acc)
     in
-    inner t n []
+    let fp, np, sa, ea = t.free_pages in
+    if (List.length fp) >= n then (
+      let pages, new_free_pages = split_list fp n [] in
+      t.free_pages <- (new_free_pages, np, sa, ea) ;
+      pages
+    ) else (
+      (* if there is not enough pages, we need to allocate a new block and update starting and ending addresses *)
+      let n_pages = max n (np * 2) in (* Default strategy is to double the number of free_pages *)
+      let pages = Io_page.get n_pages in
+      let start_address = Nativeint.to_int (Io_page.get_addr pages) in
+      let end_address = start_address + n_pages * Io_page.page_size in
+
+      let pages, new_free_pages = split_list (Io_page.to_pages pages) n [] in
+      t.free_pages <- (new_free_pages, n_pages, start_address, end_address) ;
+      pages
+    )
+
+  external unsafe_fill_bigstring : Io_page.t -> int -> int -> int -> unit = "caml_fill_bigstring" [@@noalloc]
+
+  let return_page t p =
+    let fp, np, sa, ea = t.free_pages in
+    let page_address = Nativeint.to_int (Io_page.get_addr p) in
+    (* If the page is in the current free_pages block, zero it, otherwise leave if for the finalizer *)
+    if (page_address >= sa && page_address < ea) then (
+      unsafe_fill_bigstring p 0 Io_page.page_size 0 ;
+      t.free_pages <- (p::fp, np, sa, ea) ;
+      ()
+    )
 
   let refill_requests nf =
     let num = Ring.Rpc.Front.get_free_requests nf.rx_fring in
@@ -207,7 +233,7 @@ module Make(C: S.CONFIGURATION) = struct
           Log.err (fun f -> f "received error: %d" e);
           msgs |> Lwt_list.iter_s (fun msg ->
             pop_rx_page nf msg.RX.Response.id >>= fun (page : Io_page.t) ->
-            nf.free_pages <- page::nf.free_pages ;
+            return_page nf page ;
             Lwt.return_unit
           )
       | Ok frame ->
@@ -218,7 +244,7 @@ module Make(C: S.CONFIGURATION) = struct
             pop_rx_page nf id >|= fun page ->
             let buf = Io_page.to_cstruct page in
             Cstruct.blit buf offset data !next size;
-            nf.free_pages <- page::nf.free_pages ;
+            return_page nf page ;
             next := !next + size
           ) >|= fun () ->
           assert (!next = Cstruct.length data);

--- a/lib/frontend.ml
+++ b/lib/frontend.ml
@@ -150,17 +150,13 @@ module Make(C: S.CONFIGURATION) = struct
     (* returns the first n elements of l, and l without them, assumes than l is long enough *)
     let rec split_list l n acc = match n, l with
         | 0, _ -> acc, l
-        | _n, [] -> assert false (* We assume l is long enough *)
+        | n, [] -> failwith (Printf.sprintf "Frontend wants %d pages, this is too much, fail." n) (* We assume l is long enough *)
         | n, hd::tl -> split_list tl (n-1) (hd::acc)
     in
     let fp = t.free_pages in
-    if (List.length fp) >= n then (
-      let pages, new_free_pages = split_list fp n [] in
-      t.free_pages <- new_free_pages ;
-      pages
-    ) else (
-        assert false
-    )
+    let pages, new_free_pages = split_list fp n [] in
+    t.free_pages <- new_free_pages ;
+    pages
 
   external unsafe_fill_bigstring : Io_page.t -> int -> int -> int -> unit = "caml_fill_bigstring" [@@noalloc]
 

--- a/lib/frontend.ml
+++ b/lib/frontend.ml
@@ -73,7 +73,7 @@ module Make(C: S.CONFIGURATION) = struct
     rx_map: (int, Gntref.t * Io_page.t) Hashtbl.t;
     rx_gnt: Gntref.t;
     mutable rx_id: Cstruct.uint16;
-    mutable free_pages: Io_page.t list * int * int * int;
+    mutable free_pages: Io_page.t list;
 
     evtchn: Xen_os.Eventchn.t;
     features: Features.t;
@@ -134,15 +134,10 @@ module Make(C: S.CONFIGURATION) = struct
     (* Register callback activation *)
     let backend = backend_conf.S.backend in
     C.read_mtu id >>= fun mtu ->
-    let n_pages = 64 in (* Default size for pre-allocated free pages *)
-    let pages = Io_page.get n_pages in
-    let start_address = Nativeint.to_int (Io_page.get_addr pages) in
-    (* With this formula, the semantic is that page are within [start_address, end_address[ *)
-    let end_address = start_address + n_pages * Io_page.page_size in
     return { vif_id; backend_id; tx_client; tx_gnt; tx_mutex; tx_pool;
              rx_gnt; rx_fring; rx_client; rx_map; rx_id = 0 ; stats;
              evtchn; mac; mtu; backend; features;
-             free_pages = (Io_page.to_pages (Io_page.get n_pages), n_pages, start_address, end_address); (* Pre-allocate 64*4kB=256kB of free_pages*)
+             free_pages = Io_page.to_pages (Io_page.get 256); (* Allocate 256*4kB=1MB of free_pages*)
            }
 
   (** Set of active block devices *)
@@ -158,34 +153,20 @@ module Make(C: S.CONFIGURATION) = struct
         | _n, [] -> assert false (* We assume l is long enough *)
         | n, hd::tl -> split_list tl (n-1) (hd::acc)
     in
-    let fp, np, sa, ea = t.free_pages in
+    let fp = t.free_pages in
     if (List.length fp) >= n then (
       let pages, new_free_pages = split_list fp n [] in
-      t.free_pages <- (new_free_pages, np, sa, ea) ;
+      t.free_pages <- new_free_pages ;
       pages
     ) else (
-      (* if there is not enough pages, we need to allocate a new block and update starting and ending addresses *)
-      let n_pages = max n (np * 2) in (* Default strategy is to double the number of free_pages *)
-      let pages = Io_page.get n_pages in
-      let start_address = Nativeint.to_int (Io_page.get_addr pages) in
-      let end_address = start_address + n_pages * Io_page.page_size in
-
-      let pages, new_free_pages = split_list (Io_page.to_pages pages) n [] in
-      t.free_pages <- (new_free_pages, n_pages, start_address, end_address) ;
-      pages
+        assert false
     )
 
   external unsafe_fill_bigstring : Io_page.t -> int -> int -> int -> unit = "caml_fill_bigstring" [@@noalloc]
 
   let return_page t p =
-    let fp, np, sa, ea = t.free_pages in
-    let page_address = Nativeint.to_int (Io_page.get_addr p) in
-    (* If the page is in the current free_pages block, zero it, otherwise leave if for the finalizer *)
-    if (page_address >= sa && page_address < ea) then (
-      unsafe_fill_bigstring p 0 Io_page.page_size 0 ;
-      t.free_pages <- (p::fp, np, sa, ea) ;
-      ()
-    )
+    unsafe_fill_bigstring p 0 Io_page.page_size 0 ;
+    t.free_pages <- p::t.free_pages
 
   let refill_requests nf =
     let num = Ring.Rpc.Front.get_free_requests nf.rx_fring in

--- a/lib/frontend.ml
+++ b/lib/frontend.ml
@@ -155,7 +155,7 @@ module Make(C: S.CONFIGURATION) = struct
     (* returns the first n elements of l, and l without them, assumes than l is long enough *)
     let rec split_list l n acc = match n, l with
         | 0, _ -> acc, l
-        | n, [] -> assert false (* We assume l is long enough *)
+        | _n, [] -> assert false (* We assume l is long enough *)
         | n, hd::tl -> split_list tl (n-1) (hd::acc)
     in
     let fp, np, sa, ea = t.free_pages in

--- a/lib/frontend.ml
+++ b/lib/frontend.ml
@@ -73,6 +73,7 @@ module Make(C: S.CONFIGURATION) = struct
     rx_map: (int, Gntref.t * Io_page.t) Hashtbl.t;
     rx_gnt: Gntref.t;
     mutable rx_id: Cstruct.uint16;
+    mutable free_pages: Io_page.t list;
 
     evtchn: Xen_os.Eventchn.t;
     features: Features.t;
@@ -135,7 +136,7 @@ module Make(C: S.CONFIGURATION) = struct
     C.read_mtu id >>= fun mtu ->
     return { vif_id; backend_id; tx_client; tx_gnt; tx_mutex; tx_pool;
              rx_gnt; rx_fring; rx_client; rx_map; rx_id = 0 ; stats;
-             evtchn; mac; mtu; backend; features;
+             evtchn; mac; mtu; backend; features; free_pages = [];
            }
 
   (** Set of active block devices *)
@@ -144,12 +145,27 @@ module Make(C: S.CONFIGURATION) = struct
   let notify nf () =
     Xen_os.Eventchn.notify h nf.evtchn
 
+  let take_pages t n =
+    let rec inner t n acc =
+      if n==0 then acc
+      else (
+        match t.free_pages with
+        | hd::tl ->
+          t.free_pages <- tl;
+          inner t (n-1) (hd::acc)
+        | [] ->
+          let pages = Io_page.pages n in
+          List.append pages acc
+      )
+    in
+    inner t n []
+
   let refill_requests nf =
     let num = Ring.Rpc.Front.get_free_requests nf.rx_fring in
     if num > 0 then
       Export.get_n num
       >>= fun grefs ->
-      let pages = Io_page.pages num in
+      let pages = take_pages nf num in
       List.iter
         (fun (gref, page) ->
            let rec next () =
@@ -190,6 +206,7 @@ module Make(C: S.CONFIGURATION) = struct
           Log.err (fun f -> f "received error: %d" e);
           msgs |> Lwt_list.iter_s (fun msg ->
             pop_rx_page nf msg.RX.Response.id >>= fun (_ : Io_page.t) ->
+            nf.free_pages <- page::nf.free_pages ;
             Lwt.return_unit
           )
       | Ok frame ->
@@ -200,6 +217,7 @@ module Make(C: S.CONFIGURATION) = struct
             pop_rx_page nf id >|= fun page ->
             let buf = Io_page.to_cstruct page in
             Cstruct.blit buf offset data !next size;
+            nf.free_pages <- page::nf.free_pages ;
             next := !next + size
           ) >|= fun () ->
           assert (!next = Cstruct.length data);


### PR DESCRIPTION
While investigating resource usage with qubes-mirage-firewall, I observed that a page is allocated for each incoming packet from a client. After some digging, this page is allocated by `Io_page.pages num` with num=1 in `refill_requests`. This PR therefore wants to avoid certain allocations by maintaining a list of pages already allocated. and reuse them once the date has been copied.

As this is a mutable field, there are precautions to be taken about daring things to review :)
We also may find the needs for blanking the pages before adding them in the list?