### PR TITLE
read MTU from xenstore if available, default to 1500

### DIFF
--- a/lib/xenstore.ml
+++ b/lib/xenstore.ml
@@ -83,7 +83,16 @@ module Make(Xs: Xs_client_lwt.S) = struct
   let backend_mac = Macaddr.of_string_exn "fe:ff:ff:ff:ff:ff"
   let read_backend_mac _ = return backend_mac
 
-  let read_mtu _id = return 1500 (* TODO *)
+  let read_mtu id =
+    frontend id
+    >>= fun frontend ->
+    Xs.make ()
+    >>= fun xsc ->
+    Lwt.catch
+      (fun () ->
+         Xs.(immediate xsc (fun h -> read h (frontend / "mtu")))
+         >|= int_of_string)
+      (fun _ -> return 1500)
 
   let read_features side path =
     Xs.make ()


### PR DESCRIPTION
To avoid being left out of the party, let's read it from the xenstore.

According to https://xenbits.xen.org/docs/unstable/hypercall/x86_64/include,public,io,netif.h.html and https://xenbits.xen.org/docs/unstable/misc/xenstore-paths.html this is supposed to work this way.

//cc @palainp also, party is https://github.com/Solo5/solo5/pull/606

EDIT: please keep in mind this PR hasn't been tested at all since I do not have access to a Xen or QubesOS machine easily.