### PR TITLE
Road to GSO part2

### DIFF
--- a/lib/assemble.ml
+++ b/lib/assemble.ml
@@ -53,6 +53,9 @@ module type CHANNEL = sig
   val flags : t -> Flags.t
   val size : t -> (int, error) result
   val gref : t -> int32
+
+  val set_extras : t -> Extra.t list -> t
+  val extras : t -> Extra.t list
 end
 
 module RX_Channel : CHANNEL with
@@ -77,6 +80,9 @@ module RX_Channel : CHANNEL with
   let size msg = msg.RX.Response.size
   (* The page is the reader's own, found from the id. *)
   let gref _msg = 0l
+
+  let set_extras msg extras = {msg with RX.Response.extras = extras}
+  let extras msg = msg.RX.Response.extras
 end
 
 module TX_Channel : CHANNEL with
@@ -103,17 +109,59 @@ module TX_Channel : CHANNEL with
   let flags msg = msg.TX.Request.flags
   let size msg = TX.Request.size msg
   let gref msg = msg.TX.Request.gref
+
+  let set_extras msg extras = {msg with TX.Request.extras = extras}
+  let extras msg = msg.TX.Request.extras
 end
 
 module Make_Reader(C : CHANNEL) = struct
 
-  let collect_messages ack_fn =
+  (* A descriptor sits in the slot after the message it qualifies and carries no
+     data, so it has to be recognised rather than read as another message. *)
+  let collect_messages ?(with_extras=false) ack_fn =
     let messages = ref [] in
+    let pending_msg = ref None in
+    let pending_extras = ref [] in
+
     ack_fn (fun slot ->
-      match C.read slot with
-      | Error e -> Log.warn (fun f -> f "[%s] Bad msg: %s" C.name e)
-      | Ok msg -> messages := msg :: !messages
+      if with_extras then (
+        match !pending_msg with
+        | Some base_msg ->
+            begin match Extra.read slot with
+            | Error e ->
+                Log.warn (fun f -> f "[%s] Drop bad extra_info: %s" C.name e);
+                messages := base_msg :: !messages;
+                pending_msg := None;
+                pending_extras := []
+            | Ok extra ->
+                pending_extras := extra :: !pending_extras;
+                (* Bit 0 of flags: 0 = last extra, 1 = more extras *)
+                if extra.Extra.flags land 1 = 0 then (
+                  messages := C.set_extras base_msg (List.rev !pending_extras) :: !messages;
+                  pending_msg := None;
+                  pending_extras := []
+                )
+            end
+        | None ->
+            match C.read slot with
+            | Error e -> Log.warn (fun f -> f "[%s] Bad msg: %s" C.name e)
+            | Ok msg ->
+                if Flags.(mem extra_info) (C.flags msg) then
+                  pending_msg := Some msg
+                else
+                  messages := msg :: !messages
+      ) else (
+        match C.read slot with
+        | Error e -> Log.warn (fun f -> f "[%s] Bad msg: %s" C.name e)
+        | Ok msg -> messages := msg :: !messages
+      )
     );
+    if with_extras then (
+      match !pending_msg with
+      | Some base_msg ->
+          Log.warn (fun f -> f "[%s] Orphan message recovered" C.name);
+          messages := C.set_extras base_msg (List.rev !pending_extras) :: !messages
+      | None -> ());
     List.rev !messages
 
   (* Enough to release the page and grant, without trusting the size field. *)
@@ -177,8 +225,8 @@ module Make_Reader(C : CHANNEL) = struct
         ) continuation_msgs rest_sizes in
         Ok { total_size; fragments = first_fragment :: rest_fragments }
 
-  let read_packets ack_fn =
-    let messages = collect_messages ack_fn in
+  let read_packets ?with_extras ack_fn =
+    let messages = collect_messages ?with_extras ack_fn in
     let packets = group_into_packets messages in
     Log.debug (fun f -> f "[%s.Reader] read_packets: %d messages -> %d packets (%d dropped)"
       C.name (List.length messages) (List.length packets)
@@ -190,13 +238,14 @@ module RX_Reader = Make_Reader(RX_Channel)
 module TX_Reader = Make_Reader(TX_Channel)
 
 module type IO = sig
-  val read_packets : ack_fn:((Cstruct.t -> unit) -> unit) -> assembled list
+  val read_packets :
+    with_extras:bool -> ack_fn:((Cstruct.t -> unit) -> unit) -> assembled list
 end
 
 module RX_IO : IO = struct
-  let read_packets ~ack_fn = RX_Reader.read_packets ack_fn
+  let read_packets ~with_extras ~ack_fn = RX_Reader.read_packets ~with_extras ack_fn
 end
 
 module TX_IO : IO = struct
-  let read_packets ~ack_fn = TX_Reader.read_packets ack_fn
+  let read_packets ~with_extras ~ack_fn = TX_Reader.read_packets ~with_extras ack_fn
 end

--- a/lib/assemble.ml
+++ b/lib/assemble.ml
@@ -18,11 +18,6 @@
 let src = Logs.Src.create "assemble" ~doc:"mirage-net-xen.assemble"
 module Log = (val Logs.src_log src : Logs.LOG)
 
-(* Extra_info descriptors parsed off a ring since boot, across every reader.
-   Tells a caller whether the peer really sends aggregated frames, which the
-   fragment count alone cannot say. *)
-let extras_seen = ref 0
-
 type fragment = {
   id: int;
   offset: int;
@@ -148,7 +143,6 @@ module Make_Reader(C : CHANNEL) = struct
                 pending_msg := None;
                 pending_extras := []
             | Ok extra ->
-                incr extras_seen;
                 pending_extras := extra :: !pending_extras;
                 (* Bit 0 of flags: 0 = last extra, 1 = more extras *)
                 if extra.Extra.flags land 1 = 0 then (

--- a/lib/assemble.ml
+++ b/lib/assemble.ml
@@ -18,6 +18,11 @@
 let src = Logs.Src.create "assemble" ~doc:"mirage-net-xen.assemble"
 module Log = (val Logs.src_log src : Logs.LOG)
 
+(* Extra_info descriptors parsed off a ring since boot, across every reader.
+   Tells a caller whether the peer really sends aggregated frames, which the
+   fragment count alone cannot say. *)
+let extras_seen = ref 0
+
 type fragment = {
   id: int;
   offset: int;
@@ -143,6 +148,7 @@ module Make_Reader(C : CHANNEL) = struct
                 pending_msg := None;
                 pending_extras := []
             | Ok extra ->
+                incr extras_seen;
                 pending_extras := extra :: !pending_extras;
                 (* Bit 0 of flags: 0 = last extra, 1 = more extras *)
                 if extra.Extra.flags land 1 = 0 then (

--- a/lib/assemble.ml
+++ b/lib/assemble.ml
@@ -28,6 +28,15 @@ type fragment = {
 type packet = {
   total_size: int;
   fragments: fragment list;
+  (* Ring ids of the slots that extra_info descriptors consumed. Such a slot
+     cost the reader whatever a slot costs, a page on the receive ring, but
+     carries no data and yields no fragment, so nothing else would give it back.
+
+     Derived by position: a descriptor sits in the slot after the message it
+     qualifies and ids run consecutively. That only holds where the reader
+     assigned the ids, so a backend reading ids its peer chose must not use
+     these. *)
+  extra_ids: int list;
 }
 
 (* [Error frags] reports the fragments of a packet that could not be assembled,
@@ -205,6 +214,11 @@ module Make_Reader(C : CHANNEL) = struct
         (List.length rest_sizes + 1));
       Error (List.map fragment_of_msg (first_msg :: continuation_msgs))
     | Ok declared_size, (rest_sizes, []) ->
+      let extra_ids =
+        List.mapi
+          (fun k _ -> (C.id first_msg + k + 1) land 0xffff)
+          (C.extras first_msg)
+      in
       let total_size, first_fragment_size =
         C.compute_sizes_read ~declared_size ~rest_sizes in
       (* The TX subtraction goes negative if the peer announces sizes that do
@@ -223,7 +237,7 @@ module Make_Reader(C : CHANNEL) = struct
         let rest_fragments = List.map2 (fun msg size ->
           { id = C.id msg; offset = C.offset msg; size; gref = C.gref msg }
         ) continuation_msgs rest_sizes in
-        Ok { total_size; fragments = first_fragment :: rest_fragments }
+        Ok { total_size; fragments = first_fragment :: rest_fragments; extra_ids }
 
   let read_packets ?with_extras ack_fn =
     let messages = collect_messages ?with_extras ack_fn in

--- a/lib/assemble.ml
+++ b/lib/assemble.ml
@@ -127,7 +127,7 @@ module Make_Reader(C : CHANNEL) = struct
 
   (* A descriptor sits in the slot after the message it qualifies and carries no
      data, so it has to be recognised rather than read as another message. *)
-  let collect_messages ?(with_extras=false) ack_fn =
+  let collect_messages ~with_extras ack_fn =
     let messages = ref [] in
     let pending_msg = ref None in
     let pending_extras = ref [] in
@@ -239,8 +239,8 @@ module Make_Reader(C : CHANNEL) = struct
         ) continuation_msgs rest_sizes in
         Ok { total_size; fragments = first_fragment :: rest_fragments; extra_ids }
 
-  let read_packets ?with_extras ack_fn =
-    let messages = collect_messages ?with_extras ack_fn in
+  let read_packets ~with_extras ack_fn =
+    let messages = collect_messages ~with_extras ack_fn in
     let packets = group_into_packets messages in
     Log.debug (fun f -> f "[%s.Reader] read_packets: %d messages -> %d packets (%d dropped)"
       C.name (List.length messages) (List.length packets)

--- a/lib/assemble.mli
+++ b/lib/assemble.mli
@@ -39,9 +39,6 @@ type packet = {
           for a backend reading ids its peer chose. *)
 }
 
-val extras_seen : int ref
-(** Extra_info descriptors parsed off a ring since boot, across every reader. *)
-
 type assembled = (packet, fragment list) result
 (** [Error frags] reports the fragments of a packet that could not be assembled,
     so the caller can release their pages and grants rather than leak them.

--- a/lib/assemble.mli
+++ b/lib/assemble.mli
@@ -36,8 +36,11 @@ type assembled = (packet, fragment list) result
     Reading never raises on peer-controlled data. *)
 
 module type IO = sig
-  val read_packets : ack_fn:((Cstruct.t -> unit) -> unit) -> assembled list
-  (** Drains the ring through [ack_fn], which hands over each slot in turn. *)
+  val read_packets :
+    with_extras:bool -> ack_fn:((Cstruct.t -> unit) -> unit) -> assembled list
+  (** Drains the ring through [ack_fn], which hands over each slot in turn.
+      [with_extras] says whether extra_info descriptors may follow a message,
+      which is only so once this end has advertised a feature that uses them. *)
 end
 
 module RX_IO : IO

--- a/lib/assemble.mli
+++ b/lib/assemble.mli
@@ -28,6 +28,15 @@ type fragment = {
 type packet = {
   total_size: int;
   fragments: fragment list;
+  extra_ids: int list;
+      (** Ring ids of slots consumed by extra_info descriptors. Such a slot cost
+          the reader whatever a slot costs, a page on the receive ring, but
+          carries no data and yields no fragment, so a caller that does not
+          release these leaks one per aggregated frame.
+
+          Derived by position, which is only sound where the reader assigned the
+          ids: valid for a frontend reading responses to its own requests, not
+          for a backend reading ids its peer chose. *)
 }
 
 type assembled = (packet, fragment list) result

--- a/lib/assemble.mli
+++ b/lib/assemble.mli
@@ -39,6 +39,9 @@ type packet = {
           for a backend reading ids its peer chose. *)
 }
 
+val extras_seen : int ref
+(** Extra_info descriptors parsed off a ring since boot, across every reader. *)
+
 type assembled = (packet, fragment list) result
 (** [Error frags] reports the fragments of a packet that could not be assembled,
     so the caller can release their pages and grants rather than leak them.

--- a/lib/dune
+++ b/lib/dune
@@ -1,7 +1,7 @@
 (library
  (name mirage_net_xen)
  (public_name mirage-net-xen)
- (modules Xenstore S Stats Flags RX TX Features
+ (modules Xenstore S Stats Flags RX TX Features Extra
    Shared_page_pool Assemble Netif)
  (wrapped false)
  (libraries cstruct macaddr mirage-xen lwt-dllist logs mirage-net io-page))

--- a/lib/extra.ml
+++ b/lib/extra.ml
@@ -1,0 +1,45 @@
+type t = {
+  typ : int;       (* uint8 *)
+  flags : int;     (* uint8 *)
+  gso_size : int;  (* uint16 *)
+  gso_type : int;  (* uint8 *)
+  gso_pad : int;   (* uint8 *)
+}
+
+let get_extra_type c = Cstruct.get_uint8 c 0
+let get_extra_flags c = Cstruct.get_uint8 c 1
+let get_extra_gso_size c = Cstruct.LE.get_uint16 c 2
+let get_extra_gso_type c = Cstruct.get_uint8 c 4
+let get_extra_gso_pad c = Cstruct.get_uint8 c 5
+
+let set_extra_type c typ = Cstruct.set_uint8 c 0 typ
+let set_extra_flags c flags = Cstruct.set_uint8 c 1 flags
+let set_extra_gso_size c size = Cstruct.LE.set_uint16 c 2 size
+let set_extra_gso_type c typ = Cstruct.set_uint8 c 4 typ
+let set_extra_gso_pad c pad = Cstruct.set_uint8 c 5 pad
+
+let read slot =
+  let typ = get_extra_type slot in
+  let flags = get_extra_flags slot in
+  (* Type values:
+     0 -> None
+     1 -> NETIF_EXTRA_TYPE_CSUM
+     2 -> NETIF_EXTRA_TYPE_GSO
+     3 -> NETIF_EXTRA_TYPE_TSO *)
+  if typ = 2 then ( (* NETIF_EXTRA_TYPE_GSO *)
+    let gso_size = get_extra_gso_size slot in
+    let gso_type = get_extra_gso_type slot in (* GSO type = 1 for TCPv4 *)
+    let gso_pad = get_extra_gso_pad slot in
+    Ok { typ; flags; gso_size; gso_type; gso_pad }
+  ) else (
+    Ok { typ; flags; gso_size=0; gso_type=0; gso_pad=0 }
+  )
+
+let write t slot =
+  set_extra_type slot t.typ;
+  set_extra_flags slot t.flags;
+  if t.typ = 2 then ( (* NETIF_EXTRA_TYPE_GSO *)
+    set_extra_gso_size slot t.gso_size;
+    set_extra_gso_type slot t.gso_type;
+    set_extra_gso_pad slot t.gso_pad
+  )

--- a/lib/extra.ml
+++ b/lib/extra.ml
@@ -1,3 +1,12 @@
+(* Descriptor types, from io/netif.h. Naming them matters more than it looks:
+   the values are adjacent and a wrong one is silent, since the peer simply
+   reads the descriptor it has been told it is holding. *)
+let type_none = 0
+let type_gso = 1
+let type_mcast_add = 2
+let type_mcast_del = 3
+let type_hash = 4
+
 type t = {
   typ : int;       (* uint8 *)
   flags : int;     (* uint8 *)
@@ -21,12 +30,7 @@ let set_extra_gso_pad c pad = Cstruct.set_uint8 c 5 pad
 let read slot =
   let typ = get_extra_type slot in
   let flags = get_extra_flags slot in
-  (* Type values:
-     0 -> None
-     1 -> NETIF_EXTRA_TYPE_CSUM
-     2 -> NETIF_EXTRA_TYPE_GSO
-     3 -> NETIF_EXTRA_TYPE_TSO *)
-  if typ = 2 then ( (* NETIF_EXTRA_TYPE_GSO *)
+  if typ = type_gso then (
     let gso_size = get_extra_gso_size slot in
     let gso_type = get_extra_gso_type slot in (* GSO type = 1 for TCPv4 *)
     let gso_pad = get_extra_gso_pad slot in
@@ -38,7 +42,7 @@ let read slot =
 let write t slot =
   set_extra_type slot t.typ;
   set_extra_flags slot t.flags;
-  if t.typ = 2 then ( (* NETIF_EXTRA_TYPE_GSO *)
+  if t.typ = type_gso then (
     set_extra_gso_size slot t.gso_size;
     set_extra_gso_type slot t.gso_type;
     set_extra_gso_pad slot t.gso_pad

--- a/lib/extra.ml
+++ b/lib/extra.ml
@@ -7,6 +7,11 @@ let type_mcast_add = 2
 let type_mcast_del = 3
 let type_hash = 4
 
+(* Which protocol the peer is asked to segment, from io/netif.h. *)
+let gso_type_none = 0
+let gso_type_tcpv4 = 1
+let gso_type_tcpv6 = 2
+
 type t = {
   typ : int;       (* uint8 *)
   flags : int;     (* uint8 *)

--- a/lib/extra.mli
+++ b/lib/extra.mli
@@ -1,0 +1,10 @@
+type t = {
+  typ : int;       (* uint8 *)
+  flags : int;     (* uint8 *)
+  gso_size : int;  (* uint16 *)
+  gso_type : int;  (* uint8 *)
+  gso_pad : int;   (* uint8 *)
+}
+
+val read: Cstruct.t -> (t, string) result
+val write: t -> Cstruct.t -> unit

--- a/lib/extra.mli
+++ b/lib/extra.mli
@@ -6,6 +6,12 @@ val type_mcast_add : int
 val type_mcast_del : int
 val type_hash : int
 
+(** GSO types, from io/netif.h. *)
+
+val gso_type_none : int
+val gso_type_tcpv4 : int
+val gso_type_tcpv6 : int
+
 type t = {
   typ : int;       (* uint8 *)
   flags : int;     (* uint8 *)

--- a/lib/extra.mli
+++ b/lib/extra.mli
@@ -1,3 +1,11 @@
+(** Descriptor types, from io/netif.h. *)
+
+val type_none : int
+val type_gso : int
+val type_mcast_add : int
+val type_mcast_del : int
+val type_hash : int
+
 type t = {
   typ : int;       (* uint8 *)
   flags : int;     (* uint8 *)

--- a/lib/features.ml
+++ b/lib/features.ml
@@ -27,8 +27,8 @@ let supported = {
   rx_copy = true;
   rx_notify = true;
   sg = true;
+  gso_tcpv4 = true;
   (* FIXME: not sure about these *)
   rx_flip = false;
-  gso_tcpv4 = false;
   smart_poll = false;
 }

--- a/lib/flags.ml
+++ b/lib/flags.ml
@@ -19,8 +19,15 @@ type t = int
 
 let empty          = 0
 
-let checksum_blank = 1
-let data_validated = 2
+(* Bits 0 and 1 swap meaning between the rings: io/netif.h gives bit 0 to
+   csum_blank and bit 1 to data_validated on transmit, and the reverse on
+   receive. Bits 2 and 3 agree, so they need no qualifier. *)
+let tx_checksum_blank = 1
+let tx_data_validated = 2
+
+let rx_data_validated = 1
+let rx_checksum_blank = 2
+
 let more_data      = 4
 let extra_info     = 8
 

--- a/lib/flags.mli
+++ b/lib/flags.mli
@@ -20,7 +20,12 @@ type t [@@deriving sexp]
 
 val empty : t
 
-val checksum_blank : t
+(** {1 Direction dependent flags}
+
+    Bits 0 and 1 swap meaning between the rings, so they are named by direction
+    and a value built for one ring must never be written to the other. *)
+
+val tx_checksum_blank : t
 (** Indicates that this is a TCP or UDP packet with an incomplete checksum.
     The separate IPv4 header checksum must always be calculated by the frontend.
     If you set this flag for other types of packet (e.g. ARP requests), then
@@ -44,7 +49,15 @@ val checksum_blank : t
     http://lists.xenproject.org/archives/html/xen-devel/2011-03/msg01901.html
   *)
 
-val data_validated : t
+val tx_data_validated : t
+(** The packet has been checked against its protocol checksum. On the transmit
+    ring this is bit 1, and csum_blank implies it. *)
+
+val rx_checksum_blank : t
+(** The receive ring's spelling of {!tx_checksum_blank}, which is bit 1 here. *)
+
+val rx_data_validated : t
+(** The receive ring's spelling of {!tx_data_validated}, which is bit 0 here. *)
 
 val more_data : t
 (** This request does not contain the entire frame. The following request

--- a/lib/netif.ml
+++ b/lib/netif.ml
@@ -59,53 +59,6 @@ type ending =
       rx_scratch: Io_page.t ;
     }
 
-(* Cheap counters for working out where the per-packet cost goes. Only integer
-   increments happen on the packet path; the summary is emitted on a timer, so
-   this must not become another hot-path logger. *)
-type counters = {
-  mutable polls: int;          (* listen iterations *)
-  mutable rx_frames: int;
-  mutable rx_fragments: int;
-  mutable rx_dropped: int;
-  mutable tx_frames: int;
-  mutable tx_fragments: int;
-  mutable reported_at: int;    (* rx_frames + tx_frames at the last summary *)
-  (* Time spent inside grant hypercalls, which only the backend performs.
-     grant_access on the frontend is a plain grant table write and costs
-     nothing comparable, so it is not counted. *)
-  mutable grant_ns: int64;
-  mutable grant_ops: int;
-  mutable last_ns: int64;      (* clock at the last summary, for exact rates *)
-  (* Frames handed over with a GSO descriptor attached. Without this there is no
-     telling an aggregating link from one that never had a frame worth it. *)
-  mutable tx_aggregated: int;
-  (* Of those, the ones spanning more than one page, which are the only ones
-     setting more_data alongside the descriptor. Kept apart because a fault that
-     touches only the multi-slot form is invisible in the total. *)
-  mutable tx_aggregated_multi: int;
-}
-
-(* On a timer rather than every N frames, so the counters keep coming when
-   throughput collapses, which is exactly when they are wanted. *)
-let report_interval_ns = 1_000_000_000L
-
-(* solo5_clock_monotonic, already linked in by mirage-xen's clock_stubs.c. Not
-   re-exported through Xen_os, hence the direct declaration. *)
-external monotonic_ns : unit -> int64 = "caml_get_monotonic_time"
-
-let new_counters () = {
-  polls = 0; rx_frames = 0; rx_fragments = 0; rx_dropped = 0;
-  tx_frames = 0; tx_fragments = 0; reported_at = 0;
-  grant_ns = 0L; grant_ops = 0; last_ns = monotonic_ns ();
-  tx_aggregated = 0; tx_aggregated_multi = 0;
-}
-
-(* Charge the time since [before] to the grant total. Call sites read the clock
-   themselves rather than passing a closure, so nothing is allocated here. *)
-let account_grant c ~before ~ops =
-  c.grant_ns <- Int64.add c.grant_ns (Int64.sub (monotonic_ns ()) before);
-  c.grant_ops <- c.grant_ops + ops
-
 type transport = {
   vif_id: int;
   peer_domid: int;
@@ -121,7 +74,6 @@ type transport = {
 
   evtchn: Xen_os.Eventchn.t;
   stats: Mirage_net.stats;
-  counters: counters;
   (* Set once the rings have been unmapped. The backend rings are the peer's
      pages and touching them after that is a use after free. *)
   mutable closed: bool;
@@ -313,12 +265,6 @@ module Unified_TX_Ops = struct
       else None
     in
     let use_gso = gso_mss <> None in
-    (match gso_mss with
-     | None -> ()
-     | Some _ ->
-         t.counters.tx_aggregated <- t.counters.tx_aggregated + 1;
-         if size > Io_page.page_size then
-           t.counters.tx_aggregated_multi <- t.counters.tx_aggregated_multi + 1);
     match t.ending with
     | Front { tx_pool ; tx_ring = (_, client) ; _ } -> (* Frontend *)
         let nfrags = Shared_page_pool.blocks_needed size in
@@ -387,7 +333,6 @@ module Unified_TX_Ops = struct
               (* One hypercall where map, copy and unmap took two plus the page
                  table work. Both endpoints stay inside one page: the source is
                  aligned and offset advances a page at a time. *)
-              let before = monotonic_ns () in
               let copied =
                 Xen_os.Xen.Import.copy_to
                   ~src:src_page ~src_off:(data.Cstruct.off + offset)
@@ -395,7 +340,6 @@ module Unified_TX_Ops = struct
                   ~gref:(Xen_os.Xen.Gntref.of_int32 req.RX.Request.gref)
                   ~dst_off:0 ~len:to_copy
               in
-              account_grant t.counters ~before ~ops:1;
               (* A refused copy leaves the peer's page holding whatever was
                  there, so announcing to_copy bytes would hand it a stale frame.
                  Report the failure instead. *)
@@ -565,7 +509,6 @@ module Unified_RX_Ops = struct
          return_page nf page)
 
     | Back { tx_ring ; rx_scratch ; _ } -> (* Backend: the page is the peer's, reached through its grant *)
-      let before = monotonic_ns () in
       (* Only frag.size bytes move, where the mapping cost a whole page plus the
          page table work. It lands at the offset it had in the peer's page, so
          the caller reads it exactly where it would have. *)
@@ -575,7 +518,6 @@ module Unified_RX_Ops = struct
           ~src_off:frag.Assemble.offset ~dst:rx_scratch
           ~dst_off:frag.Assemble.offset ~len:frag.Assemble.size
       in
-      account_grant nf.t.counters ~before ~ops:1;
       (match copied with
         | Ok () -> read (Io_page.to_cstruct rx_scratch)
         | Error _ -> ());
@@ -665,7 +607,7 @@ module Make(C: S.CONFIGURATION) = struct
       rx_gnt;
       rx_id = 0;
       free_pages = Io_page.to_pages (Io_page.get 256);
-      evtchn; stats = Mirage_net.Stats.create (); counters = new_counters (); closed = false;
+      evtchn; stats = Mirage_net.Stats.create (); closed = false;
       ending;
       peer_accepts_gso = peer_accepts_gso && Features.supported.gso_tcpv4;
       accepts_gso = Features.supported.gso_tcpv4;
@@ -697,7 +639,7 @@ module Make(C: S.CONFIGURATION) = struct
       rx_gnt = Xen_os.Xen.Gntref.of_int32 rx_ring_ref;
       rx_id = 0;
       free_pages = [];
-      evtchn = channel; stats = Mirage_net.Stats.create (); counters = new_counters (); closed = false;
+      evtchn = channel; stats = Mirage_net.Stats.create (); closed = false;
       ending;
       peer_accepts_gso = peer_accepts_gso && Features.supported.gso_tcpv4;
       accepts_gso;
@@ -851,8 +793,6 @@ module Make(C: S.CONFIGURATION) = struct
          if len > size then failwith "length exceeds total size";
          Unified_TX_Ops.fragment_data nf.t ?src_page (Cstruct.sub data 0 len)
          >|= fun fragments -> (len, fragments)) >|= fun (total_size, fragments) ->
-      nf.t.counters.tx_frames <- nf.t.counters.tx_frames + 1;
-      nf.t.counters.tx_fragments <- nf.t.counters.tx_fragments + List.length fragments;
       Unified_TX_Ops.notify_if_needed nf.t;
       Stats.tx nf.t.stats (Int64.of_int total_size);
       Lwt.join (List.map snd fragments))
@@ -907,15 +847,12 @@ module Make(C: S.CONFIGURATION) = struct
       | Error frags ->
         Log.warn (fun f -> f "[%s-RX] Dropping unassembled packet (%d fragments)"
           (direction nf) (List.length frags));
-        nf.t.counters.rx_dropped <- nf.t.counters.rx_dropped + 1;
         Unified_RX_Ops.discard_fragments nf frags
       | Ok packet ->
         Lwt.catch (fun () ->
           assemble_packet packet (Unified_RX_Ops.with_page nf) >>= fun data ->
           Unified_RX_Ops.release_extra_slots nf packet.Assemble.extra_ids
           >>= fun () ->
-          nf.t.counters.rx_frames <- nf.t.counters.rx_frames + 1;
-          nf.t.counters.rx_fragments <- nf.t.counters.rx_fragments + List.length packet.Assemble.fragments;
           Stats.rx nf.t.stats (Int64.of_int packet.Assemble.total_size);
           (* Lwt.async here would let the next frame start before this one has
              finished, and would put the callback outside the catch below. The
@@ -926,53 +863,11 @@ module Make(C: S.CONFIGURATION) = struct
             (direction nf) (Printexc.to_string ex));
           Lwt.return_unit))
 
-  (* frames/poll is the batching factor: close to 1 means a full event channel
-     wake-up per frame. fragments/frame is how many ring slots and page copies
-     each frame costs. grant_share is the fraction of wall time spent inside
-     grant hypercalls, which is the cost this driver can actually act on. *)
-  let report_counters nf =
-    let c = nf.t.counters in
-    let ratio a b = if b = 0 then 0.0 else float_of_int a /. float_of_int b in
-    let now = monotonic_ns () in
-    let elapsed_ns = Int64.sub now c.last_ns in
-    let elapsed_s = Int64.to_float elapsed_ns /. 1e9 in
-    let frames_this_round = c.rx_frames + c.tx_frames - c.reported_at in
-    let ops_per_s =
-      if elapsed_s > 0.0 then float_of_int frames_this_round /. elapsed_s else 0.0 in
-    let grant_us = Int64.to_float c.grant_ns /. 1e3 in
-    let grant_share =
-      if elapsed_ns > 0L then Int64.to_float c.grant_ns /. Int64.to_float elapsed_ns
-      else 0.0 in
-    Log.debug (fun f -> f
-      "[%s] counters: polls=%d rx_frames=%d frags/frame=%.2f frames/poll=%.2f \
-       rx_dropped=%d tx_frames=%d tx_frags/frame=%.2f free_pages=%d \
-       ops/s=%.0f grant_ops=%d grant_us/op=%.2f grant_share=%.1f%% \
-       tx_aggregated=%d tx_agg_multi=%d extras_seen=%d"
-      (direction nf) c.polls c.rx_frames
-      (ratio c.rx_fragments c.rx_frames)
-      (ratio c.rx_frames c.polls)
-      c.rx_dropped c.tx_frames
-      (ratio c.tx_fragments c.tx_frames)
-      (List.length nf.t.free_pages)
-      ops_per_s c.grant_ops
-      (if c.grant_ops = 0 then 0.0 else grant_us /. float_of_int c.grant_ops)
-      (grant_share *. 100.0)
-      c.tx_aggregated c.tx_aggregated_multi !Assemble.extras_seen);
-    (* grant_ns and grant_ops are per round, so the share is of this round. *)
-    c.reported_at <- c.rx_frames + c.tx_frames;
-    c.last_ns <- now;
-    c.grant_ns <- 0L;
-    c.grant_ops <- 0
-
   let listen nf ~header_size:_ callback =
     let rec loop after =
-      let c = nf.t.counters in
-      c.polls <- c.polls + 1;
       rx_poll nf callback >>= fun () ->
       Unified_RX_Ops.post_receive nf >>= fun () ->
       Unified_RX_Ops.notify_if_needed nf;
-      if Int64.sub (monotonic_ns ()) c.last_ns >= report_interval_ns then
-        report_counters nf;
       (match nf.t.ending with
        | Front { tx_ring = _fring, client ; _ } ->
            Lwt_ring.Front.poll client (fun slot ->

--- a/lib/netif.ml
+++ b/lib/netif.ml
@@ -76,6 +76,13 @@ type counters = {
   mutable grant_ns: int64;
   mutable grant_ops: int;
   mutable last_ns: int64;      (* clock at the last summary, for exact rates *)
+  (* Frames handed over with a GSO descriptor attached. Without this there is no
+     telling an aggregating link from one that never had a frame worth it. *)
+  mutable tx_aggregated: int;
+  (* Of those, the ones spanning more than one page, which are the only ones
+     setting more_data alongside the descriptor. Kept apart because a fault that
+     touches only the multi-slot form is invisible in the total. *)
+  mutable tx_aggregated_multi: int;
 }
 
 (* On a timer rather than every N frames, so the counters keep coming when
@@ -90,6 +97,7 @@ let new_counters () = {
   polls = 0; rx_frames = 0; rx_fragments = 0; rx_dropped = 0;
   tx_frames = 0; tx_fragments = 0; reported_at = 0;
   grant_ns = 0L; grant_ops = 0; last_ns = monotonic_ns ();
+  tx_aggregated = 0; tx_aggregated_multi = 0;
 }
 
 (* Charge the time since [before] to the grant total. Call sites read the clock
@@ -118,6 +126,14 @@ type transport = {
      pages and touching them after that is a use after free. *)
   mutable closed: bool;
   ending : ending;
+
+  (* The two halves of feature-gso-tcpv4, which the protocol keeps separate.
+     [peer_accepts_gso] is what the other end advertised, so it gates what we
+     put on the ring. [accepts_gso] is what we advertised, so it gates what we
+     must be ready to read: once set, every descriptor stream has to be parsed
+     for extra_info whether or not any arrives. *)
+  peer_accepts_gso: bool;
+  accepts_gso: bool;
 }
 
 type t = {
@@ -128,6 +144,13 @@ type t = {
      receive ring and grants fresh ones as the ring is refilled. *)
   get_rx_grants: transport -> int -> (Xen_os.Xen.Gntref.t * Io_page.t) list Lwt.t;
 }
+
+(* Whether this end may hand the peer a frame larger than the link, which needs
+   both that the peer agreed to segment it and that we are the side attaching the
+   descriptor saying how. Everything that promises an oversized frame and
+   everything that emits one asks this same question. *)
+let may_aggregate t =
+  (match t.tx_pool with Front _ -> false | Back _ -> true) && t.peer_accepts_gso
 
 let check_open t = if t.closed then raise Netback_shutdown
 
@@ -218,6 +241,46 @@ module Unified_TX_Ops = struct
   (* Frame lengths count this, mtu does not. The two are not interchangeable. *)
   let ethernet_header_size = 14
 
+  (* The mss a GSO descriptor carries is the MTU less the headers the peer will
+     repeat on every segment, and both lengths are in the frame itself. Assuming
+     mtu - 40 is right only for option free headers. Returning None also answers
+     whether GSO applies at all, TCPv4 being the only type on offer. *)
+  let tcpv4_mss ~mtu frame =
+    let ethertype_ipv4 = 0x0800 and ip_proto_tcp = 6 in
+    let ipv4_min = 20 and tcp_min = 20 in
+    if Cstruct.length frame < ethernet_header_size + ipv4_min then None
+    else if Cstruct.BE.get_uint16 frame 12 <> ethertype_ipv4 then None
+    else
+      let ip = Cstruct.shift frame ethernet_header_size in
+      let ihl = Cstruct.get_uint8 ip 0 land 0x0f in
+      let ip_header_size = ihl * 4 in
+      if ihl < 5 || Cstruct.length ip < ip_header_size + tcp_min then None
+      else if Cstruct.get_uint8 ip 9 <> ip_proto_tcp then None
+      else
+        let tcp = Cstruct.shift ip ip_header_size in
+        let data_offset = Cstruct.get_uint8 tcp 12 lsr 4 in
+        let tcp_header_size = data_offset * 4 in
+        if data_offset < 5 then None
+        else
+          let mss = mtu - ip_header_size - tcp_header_size in
+          if mss <= 0 then None else Some mss
+
+  (* Claim the next slot and put a GSO descriptor in it. Nothing is pushed here:
+     the caller pushes once the whole frame is on the ring, and claiming the slot
+     has already moved the producer index. No wakener is registered either, the
+     peer never answering a descriptor slot on its own account. *)
+  let write_gso_extra ending gso_size gso_type =
+    let extra =
+      { Extra.typ = Extra.type_gso; flags = 0; gso_size; gso_type; gso_pad = 0 }
+    in
+    match ending with
+    | Front { tx_ring = fring, _ ; _ } ->
+        let slot_id = Ring.Rpc.Front.next_req_id fring in
+        Extra.write extra (Ring.Rpc.Front.slot fring slot_id)
+    | Back { rx_ring ; _ } ->
+        let slot_id = Ring.Rpc.Back.next_res_id rx_ring in
+        Extra.write extra (Ring.Rpc.Back.slot rx_ring slot_id)
+
   (* The peer answers every transmit request, and a status other than OKAY means
      the frame did not go out. *)
   let check_reply replied =
@@ -234,6 +297,28 @@ module Unified_TX_Ops = struct
      once the peer has answered for it. *)
   let fragment_data t ?src_page data =
     let size = Cstruct.length data in
+    (* Decide once whether this frame goes out aggregated and with what mss, so
+       that the decision and the descriptor cannot disagree. The threshold is the
+       MTU itself: at or below it a frame needs no explaining, above it one
+       always does. [size] is a frame length and [mtu] a payload length, hence
+       the header between them.
+
+       Only the backend aggregates. On the frontend transmit path a descriptor
+       claims a request slot and the peer answers by skipping the matching
+       response slot; Lwt_ring, which owns the waker table, would read that stale
+       slot as a response. Filtering it out needs a waker table of our own. *)
+    let gso_mss =
+      if may_aggregate t && size > t.mtu + ethernet_header_size then
+        tcpv4_mss ~mtu:t.mtu data
+      else None
+    in
+    let use_gso = gso_mss <> None in
+    (match gso_mss with
+     | None -> ()
+     | Some _ ->
+         t.counters.tx_aggregated <- t.counters.tx_aggregated + 1;
+         if size > Io_page.page_size then
+           t.counters.tx_aggregated_multi <- t.counters.tx_aggregated_multi + 1);
     match t.ending with
     | Front { tx_pool ; tx_ring = (_, client) ; _ } -> (* Frontend *)
         let nfrags = Shared_page_pool.blocks_needed size in
@@ -275,7 +360,25 @@ module Unified_TX_Ops = struct
                 "Netif.fragment_data: the backend needs a page aligned source"
         in
         let pages_needed = max 1 @@ Io_page.round_to_page_size size / Io_page.page_size in
+        (* A descriptor overlays a response, and the frontend pairs responses
+           with requests by ring position: the id field is part of what the
+           descriptor overlays, so there is nothing else it could use. io/netif.h
+           makes this the backend's problem, the descriptor having to sit in the
+           slot of a request that was actually consumed. So take one request more
+           than there are pages; its grant goes unused, only its slot is wanted.
+           Writing one more response than we consume requests is what puts the
+           two streams permanently out of step. *)
+        let slots_needed = if use_gso then pages_needed + 1 else pages_needed in
         backend_get_n_grefs t rx_ring rx_grants pages_needed >>= fun reqs ->
+        (* The descriptor follows the first response, so the second consumed
+           request is the one spent on it. *)
+        let reqs =
+          if use_gso then
+            match reqs with
+            | first :: _spent_on_the_descriptor :: rest -> first :: rest
+            | _ -> reqs
+          else reqs
+        in
 
         let rec copy_to_peer offset acc_frags = function
           | [] -> return (List.rev acc_frags)
@@ -311,14 +414,20 @@ module Unified_TX_Ops = struct
                 gref = req.RX.Request.gref;
               } in
               let has_more = (rest <> []) in
-              let flags = if has_more then Flags.more_data else Flags.empty in
-
+              let is_first = (offset = 0) in
+              let flags =
+                Flags.((if has_more then more_data else empty)
+                       ++ (if is_first && use_gso then extra_info else empty))
+              in
               let slot = Ring.Rpc.Back.(slot rx_ring (next_res_id rx_ring)) in
               (* Each RX response carries the size of its own fragment. *)
               let resp = { RX.Response.id = req.RX.Request.id; offset = 0;
                            flags; size = resp_size; extras = [] } in
               RX.Response.write resp slot
-              copy_to_peer (offset + to_copy) ((frag, Lwt.return_unit) :: acc_frags) rest
+              (match (if is_first then gso_mss else None) with
+               | None -> ()
+               | Some mss ->
+                   write_gso_extra t.rx_ring mss Extra.gso_type_tcpv4);
         in
         copy_to_peer 0 [] reqs
 
@@ -367,10 +476,10 @@ module Unified_RX_Ops = struct
     match nf.t.ending with
     | Front { rx_ring = ring, _ ; _}  -> (* Frontend reads responses on RX *)
       let ack_fn = Ring.Rpc.Front.ack_responses ring in
-      Assemble.RX_IO.read_packets ~ack_fn ~with_extras:Features.supported.gso_tcpv4
+      Assemble.RX_IO.read_packets ~ack_fn ~with_extras:nf.t.accepts_gso
     | Back { tx_ring ; _ } -> (* Backend reads requests on TX *)
       let ack_fn = Ring.Rpc.Back.ack_requests tx_ring in
-      Assemble.TX_IO.read_packets ~ack_fn ~with_extras:Features.supported.gso_tcpv4
+      Assemble.TX_IO.read_packets ~ack_fn ~with_extras:nf.t.accepts_gso
 
   external unsafe_fill_bigstring : Io_page.t -> int -> int -> int -> unit
     = "caml_fill_bigstring" [@@noalloc]
@@ -417,9 +526,8 @@ module Unified_RX_Ops = struct
      undone and the peer's transmit ring fills up and it stops sending. A NULL
      status is what says "nothing here". *)
   let release_extra_slots nf ids =
-    match nf.t.tx_pool with
-    | Some _ -> (* Frontend: the page is ours *)
-      let rx_map = Option.get nf.t.rx_map in
+    match nf.t.ending with
+    | Front { rx_map ; _ } -> (* Frontend: the page is ours *)
       ids |> Lwt_list.iter_s (fun id ->
         match Hashtbl.find_opt rx_map id with
         | None ->
@@ -429,14 +537,11 @@ module Unified_RX_Ops = struct
           Hashtbl.remove rx_map id;
           Export.end_access ~release_ref:true gref >|= fun () ->
           return_page nf page)
-    | None -> (* Backend: only the slot, answered so the peer reclaims it *)
+    | Back { tx_ring ; _ } -> (* Backend: only the slot, answered so the peer reclaims it *)
       List.iter (fun _id ->
-        match nf.t.tx_ring with
-        | Back_ring bring ->
-          let slot = Ring.Rpc.Back.(slot bring (next_res_id bring)) in
-          TX.Response.write
-            { TX.Response.id = 0; status = TX.Response.NULL } slot
-        | _ -> ()) ids;
+        let slot = Ring.Rpc.Back.(slot bring (next_res_id bring)) in
+        TX.Response.write
+          { TX.Response.id = 0; status = TX.Response.NULL } slot) ids ;
       Lwt.return_unit
 
   (* [read] is handed the page the fragment sits in and must take what it needs
@@ -536,7 +641,7 @@ module Make(C: S.CONFIGURATION) = struct
   (** Set of active block devices *)
   let devices : (int, t) Hashtbl.t = Hashtbl.create 1
 
-  let create_frontend ~vif_id ~backend_id ~mac ~mtu =
+  let create_frontend ~vif_id ~backend_id ~mac ~mtu ~peer_accepts_gso =
     Log.info (fun f -> f "[Frontend] Creating: id=%d domid=%d" vif_id backend_id);
     frontend_create_ring ~domid:backend_id ~idx_size:TX.total_size
       (Printf.sprintf "Netif.TX.%d" vif_id)
@@ -560,10 +665,12 @@ module Make(C: S.CONFIGURATION) = struct
       free_pages = Io_page.to_pages (Io_page.get 256);
       evtchn; stats = Mirage_net.Stats.create (); counters = new_counters (); closed = false;
       ending;
+      peer_accepts_gso = peer_accepts_gso && Features.supported.gso_tcpv4;
+      accepts_gso = Features.supported.gso_tcpv4;
     }
 
   let create_backend ~cleanup ~domid ~device_id ~frontend_mac ~mac ~mtu
-      ~tx_ring_ref ~rx_ring_ref ~event_channel =
+      ~tx_ring_ref ~rx_ring_ref ~event_channel ~peer_accepts_gso =
     Log.info (fun f -> f "[Backend] Creating: domid=%d device_id=%d" domid device_id);
     backend_import_ring ~domid ~gntref:(Xen_os.Xen.Gntref.of_int32 tx_ring_ref)
       ~idx_size:TX.total_size "Netif.Backend.TX" true
@@ -590,6 +697,8 @@ module Make(C: S.CONFIGURATION) = struct
       free_pages = [];
       evtchn = channel; stats = Mirage_net.Stats.create (); counters = new_counters (); closed = false;
       ending;
+      peer_accepts_gso = peer_accepts_gso && Features.supported.gso_tcpv4;
+      accepts_gso = Features.supported.gso_tcpv4;
     }
 
   let plug_frontend vif_id =
@@ -598,7 +707,9 @@ module Make(C: S.CONFIGURATION) = struct
     let backend_id = backend_conf.S.backend_id in
     C.read_frontend_mac id >>= fun mac ->
     C.read_mtu id >>= fun mtu ->
-    create_frontend ~vif_id ~backend_id ~mac ~mtu >>= fun transport ->
+    create_frontend ~vif_id ~backend_id ~mac ~mtu
+      ~peer_accepts_gso:backend_conf.S.features_available.gso_tcpv4
+    >>= fun transport ->
     let front_conf = { S.
       tx_ring_ref = Xen_os.Xen.Gntref.to_int32 transport.tx_gnt;
       rx_ring_ref = Xen_os.Xen.Gntref.to_int32 transport.rx_gnt;
@@ -668,6 +779,7 @@ module Make(C: S.CONFIGURATION) = struct
       ~tx_ring_ref:f.S.tx_ring_ref
       ~rx_ring_ref:f.S.rx_ring_ref
       ~event_channel:f.S.event_channel
+      ~peer_accepts_gso:f.S.feature_requests.gso_tcpv4
     >>= fun transport ->
     C.connect id >>= fun () ->
     Log.info (fun f -> f "[Backend] Connected to frontend");
@@ -827,7 +939,8 @@ module Make(C: S.CONFIGURATION) = struct
     Log.info (fun f -> f
       "[%s] counters: polls=%d rx_frames=%d frags/frame=%.2f frames/poll=%.2f \
        rx_dropped=%d tx_frames=%d tx_frags/frame=%.2f free_pages=%d \
-       ops/s=%.0f grant_ops=%d grant_us/op=%.2f grant_share=%.1f%%"
+       ops/s=%.0f grant_ops=%d grant_us/op=%.2f grant_share=%.1f%% \
+       tx_aggregated=%d tx_agg_multi=%d extras_seen=%d"
       (direction nf) c.polls c.rx_frames
       (ratio c.rx_fragments c.rx_frames)
       (ratio c.rx_frames c.polls)
@@ -836,7 +949,8 @@ module Make(C: S.CONFIGURATION) = struct
       (List.length nf.t.free_pages)
       ops_per_s c.grant_ops
       (if c.grant_ops = 0 then 0.0 else grant_us /. float_of_int c.grant_ops)
-      (grant_share *. 100.0));
+      (grant_share *. 100.0)
+      c.tx_aggregated c.tx_aggregated_multi !Assemble.extras_seen);
     (* grant_ns and grant_ops are per round, so the share is of this round. *)
     c.reported_at <- c.rx_frames + c.tx_frames;
     c.last_ns <- now;
@@ -874,8 +988,14 @@ module Make(C: S.CONFIGURATION) = struct
   let mac nf = nf.t.mac
   let mtu nf = nf.t.mtu
 
+  (* An IPv4 total length is sixteen bits, so this is the most a peer could ever
+     be asked to segment, and it is above any MTU that field can describe. *)
+  let max_aggregated_frame = 65535 + Unified_TX_Ops.ethernet_header_size
+
   (* A frame length, header included, which mtu is not. See netif.mli. *)
-  let max_frame_size nf = nf.t.mtu + Unified_TX_Ops.ethernet_header_size
+  let max_frame_size nf =
+    if may_aggregate nf.t then max_aggregated_frame
+    else nf.t.mtu + Unified_TX_Ops.ethernet_header_size
 
   let get_stats_counters nf = nf.t.stats
   let reset_stats_counters nf = Mirage_net.Stats.reset nf.t.stats

--- a/lib/netif.ml
+++ b/lib/netif.ml
@@ -245,7 +245,7 @@ module Unified_TX_Ops = struct
                 let flags = if has_more then Flags.more_data else Flags.empty in
                 let request = { TX.Request.id; gref = Xen_os.Xen.Gntref.to_int32 gref;
                                 offset = shared_block.Cstruct.off; flags;
-                                size = request_size } in
+                                size = request_size; extras = [] } in
                 Lwt_ring.Front.write client (fun slot ->
                     TX.Request.write request slot; id
                   ) >>= fun replied ->
@@ -306,7 +306,7 @@ module Unified_TX_Ops = struct
               let slot = Ring.Rpc.Back.(slot rx_ring (next_res_id rx_ring)) in
               (* Each RX response carries the size of its own fragment. *)
               let resp = { RX.Response.id = req.RX.Request.id; offset = 0;
-                           flags; size = resp_size } in
+                           flags; size = resp_size; extras = [] } in
               RX.Response.write resp slot
               copy_to_peer (offset + to_copy) ((frag, Lwt.return_unit) :: acc_frags) rest
         in
@@ -332,7 +332,7 @@ module Unified_TX_Ops = struct
           } in
           let request = { TX.Request.id; gref = Xen_os.Xen.Gntref.to_int32 gref;
                           offset = shared_block.Cstruct.off;
-                          flags = Flags.empty; size = len } in
+                          flags = Flags.empty; size = len; extras = [] } in
           Lwt_ring.Front.write client (fun slot ->
               TX.Request.write request slot; id
             ) >>= fun replied ->
@@ -357,10 +357,10 @@ module Unified_RX_Ops = struct
     match nf.t.ending with
     | Front { rx_ring = ring, _ ; _}  -> (* Frontend reads responses on RX *)
       let ack_fn = Ring.Rpc.Front.ack_responses ring in
-      Assemble.RX_IO.read_packets ~ack_fn
+      Assemble.RX_IO.read_packets ~ack_fn ~with_extras:Features.supported.gso_tcpv4
     | Back { tx_ring ; _ } -> (* Backend reads requests on TX *)
       let ack_fn = Ring.Rpc.Back.ack_requests tx_ring in
-      Assemble.TX_IO.read_packets ~ack_fn
+      Assemble.TX_IO.read_packets ~ack_fn ~with_extras:Features.supported.gso_tcpv4
 
   external unsafe_fill_bigstring : Io_page.t -> int -> int -> int -> unit
     = "caml_fill_bigstring" [@@noalloc]

--- a/lib/netif.ml
+++ b/lib/netif.ml
@@ -672,7 +672,7 @@ module Make(C: S.CONFIGURATION) = struct
     }
 
   let create_backend ~cleanup ~domid ~device_id ~frontend_mac ~mac ~mtu
-      ~tx_ring_ref ~rx_ring_ref ~event_channel ~peer_accepts_gso =
+      ~tx_ring_ref ~rx_ring_ref ~event_channel ~peer_accepts_gso ~accepts_gso =
     Log.info (fun f -> f "[Backend] Creating: domid=%d device_id=%d" domid device_id);
     backend_import_ring ~domid ~gntref:(Xen_os.Xen.Gntref.of_int32 tx_ring_ref)
       ~idx_size:TX.total_size "Netif.Backend.TX" true
@@ -700,7 +700,7 @@ module Make(C: S.CONFIGURATION) = struct
       evtchn = channel; stats = Mirage_net.Stats.create (); counters = new_counters (); closed = false;
       ending;
       peer_accepts_gso = peer_accepts_gso && Features.supported.gso_tcpv4;
-      accepts_gso = Features.supported.gso_tcpv4;
+      accepts_gso;
     }
 
   let plug_frontend vif_id =
@@ -774,7 +774,12 @@ module Make(C: S.CONFIGURATION) = struct
     Cleanup.push cleanup (fun () -> C.disconnect_backend id);
     C.read_backend_mac id >>= fun mac ->
     C.read_frontend_mac id >>= fun frontend_mac ->
-    C.init_backend id Features.supported >>= fun _backend_configuration ->
+    (* Do not invite the peer to send what we could not pass on. Only a backend
+       attaches a GSO descriptor, so a frame we accept here and have to forward
+       out of a frontend would need fragmenting, which don't-fragment forbids
+       and which loses the packet. Revisit once the frontend can aggregate. *)
+    let backend_features = { Features.supported with gso_tcpv4 = false } in
+    C.init_backend id backend_features >>= fun _backend_configuration ->
     C.read_frontend_configuration id >>= fun f ->
     C.read_mtu id >>= fun mtu ->
     create_backend ~cleanup ~domid ~device_id ~frontend_mac ~mac ~mtu
@@ -782,6 +787,7 @@ module Make(C: S.CONFIGURATION) = struct
       ~rx_ring_ref:f.S.rx_ring_ref
       ~event_channel:f.S.event_channel
       ~peer_accepts_gso:f.S.feature_requests.gso_tcpv4
+      ~accepts_gso:backend_features.Features.gso_tcpv4
     >>= fun transport ->
     C.connect id >>= fun () ->
     Log.info (fun f -> f "[Backend] Connected to frontend");

--- a/lib/netif.ml
+++ b/lib/netif.ml
@@ -45,6 +45,45 @@ type ending =
       rx_ring : (RX.Response.t, int) Ring.Rpc.Back.t ;
     }
 
+(* Cheap counters for working out where the per-packet cost goes. Only integer
+   increments happen on the packet path; the summary is emitted on a timer, so
+   this must not become another hot-path logger. *)
+type counters = {
+  mutable polls: int;          (* listen iterations *)
+  mutable rx_frames: int;
+  mutable rx_fragments: int;
+  mutable rx_dropped: int;
+  mutable tx_frames: int;
+  mutable tx_fragments: int;
+  mutable reported_at: int;    (* rx_frames + tx_frames at the last summary *)
+  (* Time spent inside grant hypercalls, which only the backend performs.
+     grant_access on the frontend is a plain grant table write and costs
+     nothing comparable, so it is not counted. *)
+  mutable grant_ns: int64;
+  mutable grant_ops: int;
+  mutable last_ns: int64;      (* clock at the last summary, for exact rates *)
+}
+
+(* On a timer rather than every N frames, so the counters keep coming when
+   throughput collapses, which is exactly when they are wanted. *)
+let report_interval_ns = 1_000_000_000L
+
+(* solo5_clock_monotonic, already linked in by mirage-xen's clock_stubs.c. Not
+   re-exported through Xen_os, hence the direct declaration. *)
+external monotonic_ns : unit -> int64 = "caml_get_monotonic_time"
+
+let new_counters () = {
+  polls = 0; rx_frames = 0; rx_fragments = 0; rx_dropped = 0;
+  tx_frames = 0; tx_fragments = 0; reported_at = 0;
+  grant_ns = 0L; grant_ops = 0; last_ns = monotonic_ns ();
+}
+
+(* Charge the time since [before] to the grant total. Call sites read the clock
+   themselves rather than passing a closure, so nothing is allocated here. *)
+let account_grant c ~before ~ops =
+  c.grant_ns <- Int64.add c.grant_ns (Int64.sub (monotonic_ns ()) before);
+  c.grant_ops <- c.grant_ops + ops
+
 type transport = {
   vif_id: int;
   peer_domid: int;
@@ -60,6 +99,7 @@ type transport = {
 
   evtchn: Xen_os.Eventchn.t;
   stats: Mirage_net.stats;
+  counters: counters;
   (* Set once the rings have been unmapped. The backend rings are the peer's
      pages and touching them after that is a use after free. *)
   mutable closed: bool;
@@ -210,10 +250,12 @@ module Unified_TX_Ops = struct
           | req :: rest ->
               let gnt = {Xen_os.Xen.Import.domid = t.peer_domid;
                          ref = Xen_os.Xen.Gntref.of_int32 req.RX.Request.gref} in
+              let before = monotonic_ns () in
               let mapping = Xen_os.Xen.Import.map_exn gnt ~writable:true in
               let dst = Xen_os.Xen.Import.Local_mapping.to_buf mapping |> Io_page.to_cstruct in
               let len, src' = Cstruct.fillv ~src ~dst in
               Xen_os.Xen.Import.Local_mapping.unmap_exn mapping;
+              account_grant t.counters ~before ~ops:2;
 
               let frag = Assemble.{
                 id = req.RX.Request.id; offset = 0; size = len;
@@ -332,10 +374,12 @@ module Unified_RX_Ops = struct
     | Back { tx_ring ; _ } -> (* Backend: the page is the peer's, reached through its grant *)
       let gnt = {Xen_os.Xen.Import.domid = nf.t.peer_domid;
                  ref = Xen_os.Xen.Gntref.of_int32 frag.Assemble.gref} in
+      let before = monotonic_ns () in
       Xen_os.Xen.Import.with_mapping gnt ~writable:false (fun mapping ->
         read (Xen_os.Xen.Import.Local_mapping.to_buf mapping |> Io_page.to_cstruct);
         Lwt.return_unit
       ) >>= fun mapped ->
+      account_grant nf.t.counters ~before ~ops:2;
       (* Answer either way, so the peer can reuse the block whether or not we
          managed to read it. *)
       let slot = Ring.Rpc.Back.(slot tx_ring (next_res_id tx_ring)) in
@@ -422,7 +466,7 @@ module Make(C: S.CONFIGURATION) = struct
       rx_gnt;
       rx_id = 0;
       free_pages = Io_page.to_pages (Io_page.get 256);
-      evtchn; stats = Mirage_net.Stats.create (); closed = false;
+      evtchn; stats = Mirage_net.Stats.create (); counters = new_counters (); closed = false;
       ending;
     }
 
@@ -451,7 +495,7 @@ module Make(C: S.CONFIGURATION) = struct
       rx_gnt = Xen_os.Xen.Gntref.of_int32 rx_ring_ref;
       rx_id = 0;
       free_pages = [];
-      evtchn = channel; stats = Mirage_net.Stats.create (); closed = false;
+      evtchn = channel; stats = Mirage_net.Stats.create (); counters = new_counters (); closed = false;
       ending;
     }
 
@@ -575,6 +619,8 @@ module Make(C: S.CONFIGURATION) = struct
          if len > size then failwith "length exceeds total size";
          Unified_TX_Ops.fragment_data nf.t (Cstruct.sub data 0 len)
          >|= fun fragments -> (len, fragments)) >|= fun (total_size, fragments) ->
+      nf.t.counters.tx_frames <- nf.t.counters.tx_frames + 1;
+      nf.t.counters.tx_fragments <- nf.t.counters.tx_fragments + List.length fragments;
       Unified_TX_Ops.notify_if_needed nf.t;
       Stats.tx nf.t.stats (Int64.of_int total_size);
       Lwt.join (List.map snd fragments))
@@ -629,11 +675,14 @@ module Make(C: S.CONFIGURATION) = struct
       | Error frags ->
         Log.warn (fun f -> f "[%s-RX] Dropping unassembled packet (%d fragments)"
           (direction nf) (List.length frags));
+        nf.t.counters.rx_dropped <- nf.t.counters.rx_dropped + 1;
         Unified_RX_Ops.discard_fragments nf frags
       | Ok packet ->
         Lwt.catch (fun () ->
           Lwt.async (fun () -> callback data)
           assemble_packet packet (Unified_RX_Ops.with_page nf) >>= fun data ->
+          nf.t.counters.rx_frames <- nf.t.counters.rx_frames + 1;
+          nf.t.counters.rx_fragments <- nf.t.counters.rx_fragments + List.length packet.Assemble.fragments;
           Stats.rx nf.t.stats (Int64.of_int packet.Assemble.total_size);
           (* Lwt.async here would let the next frame start before this one has
              finished, and would put the callback outside the catch below. The
@@ -644,11 +693,51 @@ module Make(C: S.CONFIGURATION) = struct
             (direction nf) (Printexc.to_string ex));
           Lwt.return_unit))
 
+  (* frames/poll is the batching factor: close to 1 means a full event channel
+     wake-up per frame. fragments/frame is how many ring slots and page copies
+     each frame costs. grant_share is the fraction of wall time spent inside
+     grant hypercalls, which is the cost this driver can actually act on. *)
+  let report_counters nf =
+    let c = nf.t.counters in
+    let ratio a b = if b = 0 then 0.0 else float_of_int a /. float_of_int b in
+    let now = monotonic_ns () in
+    let elapsed_ns = Int64.sub now c.last_ns in
+    let elapsed_s = Int64.to_float elapsed_ns /. 1e9 in
+    let frames_this_round = c.rx_frames + c.tx_frames - c.reported_at in
+    let ops_per_s =
+      if elapsed_s > 0.0 then float_of_int frames_this_round /. elapsed_s else 0.0 in
+    let grant_us = Int64.to_float c.grant_ns /. 1e3 in
+    let grant_share =
+      if elapsed_ns > 0L then Int64.to_float c.grant_ns /. Int64.to_float elapsed_ns
+      else 0.0 in
+    Log.info (fun f -> f
+      "[%s] counters: polls=%d rx_frames=%d frags/frame=%.2f frames/poll=%.2f \
+       rx_dropped=%d tx_frames=%d tx_frags/frame=%.2f free_pages=%d \
+       ops/s=%.0f grant_ops=%d grant_us/op=%.2f grant_share=%.1f%%"
+      (direction nf) c.polls c.rx_frames
+      (ratio c.rx_fragments c.rx_frames)
+      (ratio c.rx_frames c.polls)
+      c.rx_dropped c.tx_frames
+      (ratio c.tx_fragments c.tx_frames)
+      (List.length nf.t.free_pages)
+      ops_per_s c.grant_ops
+      (if c.grant_ops = 0 then 0.0 else grant_us /. float_of_int c.grant_ops)
+      (grant_share *. 100.0));
+    (* grant_ns and grant_ops are per round, so the share is of this round. *)
+    c.reported_at <- c.rx_frames + c.tx_frames;
+    c.last_ns <- now;
+    c.grant_ns <- 0L;
+    c.grant_ops <- 0
+
   let listen nf ~header_size:_ callback =
     let rec loop after =
+      let c = nf.t.counters in
+      c.polls <- c.polls + 1;
       rx_poll nf callback >>= fun () ->
       Unified_RX_Ops.post_receive nf >>= fun () ->
       Unified_RX_Ops.notify_if_needed nf;
+      if Int64.sub (monotonic_ns ()) c.last_ns >= report_interval_ns then
+        report_counters nf;
       (match nf.t.ending with
        | Front { tx_ring = _fring, client ; _ } ->
            Lwt_ring.Front.poll client (fun slot ->

--- a/lib/netif.ml
+++ b/lib/netif.ml
@@ -394,6 +394,41 @@ module Unified_RX_Ops = struct
         frags;
       Lwt.return_unit
 
+  (* A descriptor occupies a ring slot without carrying data, so it never becomes
+     a fragment and nothing on the assembly path accounts for it. Both roles owe
+     something for that slot and neither is optional.
+
+     As a frontend, the slot was one of our requests, so a page of ours is behind
+     it and nothing will ask for that page again: hand it back, or the pool
+     drains by one per aggregated frame until the ring can no longer be refilled.
+
+     As a backend, the slot belongs to the peer, which attached no resource to
+     it, but it is only returned once our response index passes it. Leave that
+     undone and the peer's transmit ring fills up and it stops sending. A NULL
+     status is what says "nothing here". *)
+  let release_extra_slots nf ids =
+    match nf.t.tx_pool with
+    | Some _ -> (* Frontend: the page is ours *)
+      let rx_map = Option.get nf.t.rx_map in
+      ids |> Lwt_list.iter_s (fun id ->
+        match Hashtbl.find_opt rx_map id with
+        | None ->
+          Log.warn (fun f -> f "[Frontend-RX] no page for descriptor slot %d" id);
+          Lwt.return_unit
+        | Some (gref, page) ->
+          Hashtbl.remove rx_map id;
+          Export.end_access ~release_ref:true gref >|= fun () ->
+          return_page nf page)
+    | None -> (* Backend: only the slot, answered so the peer reclaims it *)
+      List.iter (fun _id ->
+        match nf.t.tx_ring with
+        | Back_ring bring ->
+          let slot = Ring.Rpc.Back.(slot bring (next_res_id bring)) in
+          TX.Response.write
+            { TX.Response.id = 0; status = TX.Response.NULL } slot
+        | _ -> ()) ids;
+      Lwt.return_unit
+
   (* [read] is handed the page the fragment sits in and must take what it needs
      before this returns, since the page goes back to the pool or the mapping is
      torn down straight after. That is what keeps the fragment from having to be
@@ -748,6 +783,8 @@ module Make(C: S.CONFIGURATION) = struct
         Lwt.catch (fun () ->
           Lwt.async (fun () -> callback data)
           assemble_packet packet (Unified_RX_Ops.with_page nf) >>= fun data ->
+          Unified_RX_Ops.release_extra_slots nf packet.Assemble.extra_ids
+          >>= fun () ->
           nf.t.counters.rx_frames <- nf.t.counters.rx_frames + 1;
           nf.t.counters.rx_fragments <- nf.t.counters.rx_fragments + List.length packet.Assemble.fragments;
           Stats.rx nf.t.stats (Int64.of_int packet.Assemble.total_size);

--- a/lib/netif.ml
+++ b/lib/netif.ml
@@ -31,6 +31,10 @@ module Log = (val Logs.src_log src : Logs.LOG)
 
 exception Netback_shutdown
 
+(* NETIF_RSP_ERROR: the response slot could not be filled and the peer must
+   discard the frame. *)
+let netif_rsp_error = -1
+
 type ending =
   | Front of {
       tx_pool: Shared_page_pool.t ;
@@ -43,6 +47,16 @@ type ending =
       rx_grants: RX.Request.t Lwt_dllist.t ;
       tx_ring : (TX.Response.t, int) Ring.Rpc.Back.t ;
       rx_ring : (RX.Response.t, int) Ring.Rpc.Back.t ;
+      (* Page aligned scratch for the transmit path. A grant copy names each
+         endpoint as a frame plus an offset, so the local source has to be page
+         aligned, which Cstruct.create does not promise. Reused across frames,
+         so unlike a fresh Io_page it does not arrive zeroed and must be
+         cleared: the marshallers expect zeroed memory. Only touched under
+         tx_mutex. *)
+      tx_scratch: Io_page.t ;
+      (* The mirror of tx_scratch, where a received fragment lands. It needs no
+         clearing: frag.size bytes go in and exactly those come out. *)
+      rx_scratch: Io_page.t ;
     }
 
 (* Cheap counters for working out where the per-packet cost goes. Only integer
@@ -208,7 +222,7 @@ module Unified_TX_Ops = struct
   (* Split [data] over as many ring slots as it needs, and describe each one to
      the peer. Returns the fragments, each paired with a thread that completes
      once the peer has answered for it. *)
-  let fragment_data t data =
+  let fragment_data t ?src_page data =
     let size = Cstruct.length data in
     match t.ending with
     | Front { tx_pool ; tx_ring = (_, client) ; _ } -> (* Frontend *)
@@ -242,35 +256,61 @@ module Unified_TX_Ops = struct
         copy_to_pages [data] true [] nfrags
 
     | Back { rx_grants ; rx_ring ; _ } -> (* Backend *)
+        let src_page =
+          match src_page with
+          | Some page -> page
+          | None ->
+              (* write always hands the backend a page aligned buffer. *)
+              invalid_arg
+                "Netif.fragment_data: the backend needs a page aligned source"
+        in
         let pages_needed = max 1 @@ Io_page.round_to_page_size size / Io_page.page_size in
         backend_get_n_grefs t rx_ring rx_grants pages_needed >>= fun reqs ->
 
-        let rec map_and_copy src acc_frags = function
-          | [] -> Lwt.return (List.rev acc_frags)
+        let rec copy_to_peer offset acc_frags = function
+          | [] -> return (List.rev acc_frags)
           | req :: rest ->
-              let gnt = {Xen_os.Xen.Import.domid = t.peer_domid;
-                         ref = Xen_os.Xen.Gntref.of_int32 req.RX.Request.gref} in
+              let to_copy = min Io_page.page_size (size - offset) in
+              (* One hypercall where map, copy and unmap took two plus the page
+                 table work. Both endpoints stay inside one page: the source is
+                 aligned and offset advances a page at a time. *)
               let before = monotonic_ns () in
-              let mapping = Xen_os.Xen.Import.map_exn gnt ~writable:true in
-              let dst = Xen_os.Xen.Import.Local_mapping.to_buf mapping |> Io_page.to_cstruct in
-              let len, src' = Cstruct.fillv ~src ~dst in
-              Xen_os.Xen.Import.Local_mapping.unmap_exn mapping;
-              account_grant t.counters ~before ~ops:2;
+              let copied =
+                Xen_os.Xen.Import.copy_to
+                  ~src:src_page ~src_off:(data.Cstruct.off + offset)
+                  ~domid:t.peer_domid
+                  ~gref:(Xen_os.Xen.Gntref.of_int32 req.RX.Request.gref)
+                  ~dst_off:0 ~len:to_copy
+              in
+              account_grant t.counters ~before ~ops:1;
+              (* A refused copy leaves the peer's page holding whatever was
+                 there, so announcing to_copy bytes would hand it a stale frame.
+                 Report the failure instead. *)
+              let resp_size =
+                match copied with
+                | Ok () -> Ok to_copy
+                | Error (`Msg m) ->
+                    Log.err (fun f ->
+                        f "[Backend-TX] grant copy failed for id %d: %s"
+                          req.RX.Request.id m);
+                    Error netif_rsp_error
+              in
 
               let frag = Assemble.{
-                id = req.RX.Request.id; offset = 0; size = len;
+                id = req.RX.Request.id; offset = 0; size = to_copy;
                 gref = req.RX.Request.gref;
               } in
               let has_more = (rest <> []) in
               let flags = if has_more then Flags.more_data else Flags.empty in
+
               let slot = Ring.Rpc.Back.(slot rx_ring (next_res_id rx_ring)) in
               (* Each RX response carries the size of its own fragment. *)
               let resp = { RX.Response.id = req.RX.Request.id; offset = 0;
-                           flags; size = Ok len } in
-              RX.Response.write resp slot;
-              map_and_copy src' ((frag, Lwt.return_unit) :: acc_frags) rest
+                           flags; size = resp_size } in
+              RX.Response.write resp slot
+              copy_to_peer (offset + to_copy) ((frag, Lwt.return_unit) :: acc_frags) rest
         in
-        map_and_copy [data] [] reqs
+        copy_to_peer 0 [] reqs
 
   (* Fast path for a frame that fits in a single pool block: let the caller fill
      the shared block rather than fill a private buffer and copy it in. At an
@@ -371,24 +411,31 @@ module Unified_RX_Ops = struct
          Hashtbl.remove rx_map id;
          Xen_os.Xen.Export.end_access ~release_ref:true gref >|= fun () ->
          return_page nf page)
-    | Back { tx_ring ; _ } -> (* Backend: the page is the peer's, reached through its grant *)
-      let gnt = {Xen_os.Xen.Import.domid = nf.t.peer_domid;
-                 ref = Xen_os.Xen.Gntref.of_int32 frag.Assemble.gref} in
+
+    | Back { tx_ring ; rx_scratch ; _ } -> (* Backend: the page is the peer's, reached through its grant *)
       let before = monotonic_ns () in
-      Xen_os.Xen.Import.with_mapping gnt ~writable:false (fun mapping ->
-        read (Xen_os.Xen.Import.Local_mapping.to_buf mapping |> Io_page.to_cstruct);
-        Lwt.return_unit
-      ) >>= fun mapped ->
-      account_grant nf.t.counters ~before ~ops:2;
+      (* Only frag.size bytes move, where the mapping cost a whole page plus the
+         page table work. It lands at the offset it had in the peer's page, so
+         the caller reads it exactly where it would have. *)
+      let copied =
+        Xen_os.Xen.Import.copy_from ~domid:nf.t.peer_domid
+          ~gref:(Xen_os.Xen.Gntref.of_int32 frag.Assemble.gref)
+          ~src_off:frag.Assemble.offset ~dst:scratch
+          ~dst_off:frag.Assemble.offset ~len:frag.Assemble.size
+      in
+      account_grant nf.t.counters ~before ~ops:1;
+      (match copied with
+        | Ok () -> read (Io_page.to_cstruct scratch)
+        | Error _ -> ());
       (* Answer either way, so the peer can reuse the block whether or not we
          managed to read it. *)
       let slot = Ring.Rpc.Back.(slot tx_ring (next_res_id tx_ring)) in
       let status =
-        match mapped with Ok () -> TX.Response.OKAY | Error _ -> TX.Response.ERROR in
-      TX.Response.write {TX.Response.id = frag.Assemble.id; status} slot;
-      (match mapped with
-       | Error (`Msg m) -> Lwt.fail_with m
-       | Ok () -> Lwt.return_unit)
+        match copied with Ok () -> TX.Response.OKAY | Error _ -> TX.Response.ERROR in
+      TX.Response.write {TX.Response.id = frag.Assemble.id; status} slot
+      (match copied with
+        | Error (`Msg m) -> Lwt.fail_with m
+        | Ok () -> Lwt.return_unit)
 
   let notify_if_needed nf =
     match nf.t.ending with
@@ -486,7 +533,8 @@ module Make(C: S.CONFIGURATION) = struct
     Cleanup.push cleanup (fun () -> Xen_os.Eventchn.unbind h channel; Lwt.return_unit);
     Log.info (fun f -> f "[Backend] Bound to event channel: %s" event_channel);
     Xen_os.Eventchn.unmask h channel;
-    let ending = Back { peer_mac = frontend_mac ; rx_grants = Lwt_dllist.create () ; tx_ring ; rx_ring } in
+    let ending = Back { peer_mac = frontend_mac ; rx_grants = Lwt_dllist.create () ; tx_ring ; rx_ring ;
+                        tx_scratch = Io_page.get 1 ; rx_scratch = Io_page.get 1 } in
     Lwt.return {
       vif_id = device_id; peer_domid = domid;
       mac; mtu;
@@ -614,10 +662,29 @@ module Make(C: S.CONFIGURATION) = struct
        | _ ->
          (* Several blocks, or the backend, which writes into the peer's pages:
             marshal into a private buffer first, then split it. *)
-         let data = Cstruct.create size in
+         (* fillf writes into data. The backend also needs the page data sits
+            in: copy_to identifies its source by page number, so the buffer
+            must start on a page boundary, which only Io_page.t promises. *)
+         let data, src_page =
+           match nf.t.ending with
+           | Front _ -> (Cstruct.create size, None)
+           | Back { tx_scratch ; _ } when size <= Io_page.page_size ->
+               (* Reused, so clear what fillf is about to write over. Only len
+                  bytes ever reach the peer, so this is about the marshallers,
+                  not about leaking. *)
+               let cs = Cstruct.sub (Io_page.to_cstruct page) 0 size in
+               Cstruct.memset cs 0;
+               (cs, Some page)
+           | Back _ ->
+               (* Larger than the scratch, which needs an MTU above 4 kB. A
+                  fresh Io_page is aligned and comes zeroed. *)
+               let pages = Io_page.round_to_page_size size / Io_page.page_size in
+               let page = Io_page.get pages in
+               (Cstruct.sub (Io_page.to_cstruct page) 0 size, Some page)
+         in
          let len = fillf data in
          if len > size then failwith "length exceeds total size";
-         Unified_TX_Ops.fragment_data nf.t (Cstruct.sub data 0 len)
+         Unified_TX_Ops.fragment_data nf.t ?src_page (Cstruct.sub data 0 len)
          >|= fun fragments -> (len, fragments)) >|= fun (total_size, fragments) ->
       nf.t.counters.tx_frames <- nf.t.counters.tx_frames + 1;
       nf.t.counters.tx_fragments <- nf.t.counters.tx_fragments + List.length fragments;

--- a/lib/netif.ml
+++ b/lib/netif.ml
@@ -187,9 +187,16 @@ let backend_import_ring ~domid ~gntref ~idx_size name writable =
 (* Collect [n] receive requests the peer has posted, waiting on the event
    channel for more if it has not posted enough yet. *)
 let backend_get_n_grefs t rx_ring rx_grants n =
+  (* Bind the head before recursing. OCaml evaluates the arguments of a
+     constructor right to left, so [take_l seq :: take seq (n - 1)] drains the
+     queue from the far end first and hands the requests back reversed. The peer
+     pairs a response with a request by ring position alone. *)
   let rec take seq = function
     | 0 -> []
-    | n -> Lwt_dllist.take_l seq :: (take seq (n - 1)) in
+    | n ->
+        let head = Lwt_dllist.take_l seq in
+        head :: take seq (n - 1)
+  in
 
   let rec loop after =
     check_open t;

--- a/lib/netif.ml
+++ b/lib/netif.ml
@@ -80,12 +80,12 @@ type transport = {
   ending : ending;
 
   (* The two halves of feature-gso-tcpv4, which the protocol keeps separate.
-     [peer_accepts_gso] is what the other end advertised, so it gates what we
-     put on the ring. [accepts_gso] is what we advertised, so it gates what we
+     [peer_accepts_gso_v4] is what the other end advertised, so it gates what we
+     put on the ring. [accepts_gso_v4] is what we advertised, so it gates what we
      must be ready to read: once set, every descriptor stream has to be parsed
      for extra_info whether or not any arrives. *)
-  peer_accepts_gso: bool;
-  accepts_gso: bool;
+  peer_accepts_gso_v4: bool;
+  accepts_gso_v4: bool;
 }
 
 type t = {
@@ -102,7 +102,7 @@ type t = {
    descriptor saying how. Everything that promises an oversized frame and
    everything that emits one asks this same question. *)
 let may_aggregate t =
-  (match t.ending with Front _ -> false | Back _ -> true) && t.peer_accepts_gso
+  (match t.ending with Front _ -> false | Back _ -> true) && t.peer_accepts_gso_v4
 
 let check_open t = if t.closed then raise Netback_shutdown
 
@@ -422,10 +422,10 @@ module Unified_RX_Ops = struct
     match nf.t.ending with
     | Front { rx_ring = ring, _ ; _}  -> (* Frontend reads responses on RX *)
       let ack_fn = Ring.Rpc.Front.ack_responses ring in
-      Assemble.RX_IO.read_packets ~ack_fn ~with_extras:nf.t.accepts_gso
+      Assemble.RX_IO.read_packets ~ack_fn ~with_extras:nf.t.accepts_gso_v4
     | Back { tx_ring ; _ } -> (* Backend reads requests on TX *)
       let ack_fn = Ring.Rpc.Back.ack_requests tx_ring in
-      Assemble.TX_IO.read_packets ~ack_fn ~with_extras:nf.t.accepts_gso
+      Assemble.TX_IO.read_packets ~ack_fn ~with_extras:nf.t.accepts_gso_v4
 
   external unsafe_fill_bigstring : Io_page.t -> int -> int -> int -> unit
     = "caml_fill_bigstring" [@@noalloc]
@@ -585,7 +585,7 @@ module Make(C: S.CONFIGURATION) = struct
   (** Set of active block devices *)
   let devices : (int, t) Hashtbl.t = Hashtbl.create 1
 
-  let create_frontend ~vif_id ~backend_id ~mac ~mtu ~peer_accepts_gso =
+  let create_frontend ~vif_id ~backend_id ~mac ~mtu ~peer_accepts_gso_v4 =
     Log.info (fun f -> f "[Frontend] Creating: id=%d domid=%d" vif_id backend_id);
     frontend_create_ring ~domid:backend_id ~idx_size:TX.total_size
       (Printf.sprintf "Netif.TX.%d" vif_id)
@@ -609,12 +609,12 @@ module Make(C: S.CONFIGURATION) = struct
       free_pages = Io_page.to_pages (Io_page.get 256);
       evtchn; stats = Mirage_net.Stats.create (); closed = false;
       ending;
-      peer_accepts_gso = peer_accepts_gso && Features.supported.gso_tcpv4;
-      accepts_gso = Features.supported.gso_tcpv4;
+      peer_accepts_gso_v4 = peer_accepts_gso_v4 && Features.supported.gso_tcpv4;
+      accepts_gso_v4 = Features.supported.gso_tcpv4;
     }
 
   let create_backend ~cleanup ~domid ~device_id ~frontend_mac ~mac ~mtu
-      ~tx_ring_ref ~rx_ring_ref ~event_channel ~peer_accepts_gso ~accepts_gso =
+      ~tx_ring_ref ~rx_ring_ref ~event_channel ~peer_accepts_gso_v4 ~accepts_gso_v4 =
     Log.info (fun f -> f "[Backend] Creating: domid=%d device_id=%d" domid device_id);
     backend_import_ring ~domid ~gntref:(Xen_os.Xen.Gntref.of_int32 tx_ring_ref)
       ~idx_size:TX.total_size "Netif.Backend.TX" true
@@ -641,8 +641,8 @@ module Make(C: S.CONFIGURATION) = struct
       free_pages = [];
       evtchn = channel; stats = Mirage_net.Stats.create (); closed = false;
       ending;
-      peer_accepts_gso = peer_accepts_gso && Features.supported.gso_tcpv4;
-      accepts_gso;
+      peer_accepts_gso_v4 = peer_accepts_gso_v4 && Features.supported.gso_tcpv4;
+      accepts_gso_v4;
     }
 
   let plug_frontend vif_id =
@@ -652,7 +652,7 @@ module Make(C: S.CONFIGURATION) = struct
     C.read_frontend_mac id >>= fun mac ->
     C.read_mtu id >>= fun mtu ->
     create_frontend ~vif_id ~backend_id ~mac ~mtu
-      ~peer_accepts_gso:backend_conf.S.features_available.gso_tcpv4
+      ~peer_accepts_gso_v4:backend_conf.S.features_available.gso_tcpv4
     >>= fun transport ->
     let front_conf = { S.
       tx_ring_ref = Xen_os.Xen.Gntref.to_int32 transport.tx_gnt;
@@ -728,8 +728,8 @@ module Make(C: S.CONFIGURATION) = struct
       ~tx_ring_ref:f.S.tx_ring_ref
       ~rx_ring_ref:f.S.rx_ring_ref
       ~event_channel:f.S.event_channel
-      ~peer_accepts_gso:f.S.feature_requests.gso_tcpv4
-      ~accepts_gso:backend_features.Features.gso_tcpv4
+      ~peer_accepts_gso_v4:f.S.feature_requests.gso_tcpv4
+      ~accepts_gso_v4:backend_features.Features.gso_tcpv4
     >>= fun transport ->
     C.connect id >>= fun () ->
     Log.info (fun f -> f "[Backend] Connected to frontend");

--- a/lib/netif.ml
+++ b/lib/netif.ml
@@ -632,9 +632,13 @@ module Make(C: S.CONFIGURATION) = struct
         Unified_RX_Ops.discard_fragments nf frags
       | Ok packet ->
         Lwt.catch (fun () ->
-          assemble_packet packet (Unified_RX_Ops.with_page nf) >|= fun data ->
-          Stats.rx nf.t.stats (Int64.of_int packet.Assemble.total_size);
           Lwt.async (fun () -> callback data)
+          assemble_packet packet (Unified_RX_Ops.with_page nf) >>= fun data ->
+          Stats.rx nf.t.stats (Int64.of_int packet.Assemble.total_size);
+          (* Lwt.async here would let the next frame start before this one has
+             finished, and would put the callback outside the catch below. The
+             pages are already back in the pool, so waiting holds nothing. *)
+          callback data
         ) (fun ex ->
           Log.err (fun f -> f "[%s-RX] Callback FAILED with exception: %s"
             (direction nf) (Printexc.to_string ex));

--- a/lib/netif.ml
+++ b/lib/netif.ml
@@ -208,6 +208,9 @@ let backend_get_n_grefs t rx_ring rx_grants n =
   loop Xen_os.Activations.program_start
 
 module Unified_TX_Ops = struct
+  (* Frame lengths count this, mtu does not. The two are not interchangeable. *)
+  let ethernet_header_size = 14
+
   (* The peer answers every transmit request, and a status other than OKAY means
      the frame did not go out. *)
   let check_reply replied =
@@ -863,6 +866,9 @@ module Make(C: S.CONFIGURATION) = struct
 
   let mac nf = nf.t.mac
   let mtu nf = nf.t.mtu
+
+  (* A frame length, header included, which mtu is not. See netif.mli. *)
+  let max_frame_size nf = nf.t.mtu + Unified_TX_Ops.ethernet_header_size
 
   let get_stats_counters nf = nf.t.stats
   let reset_stats_counters nf = Mirage_net.Stats.reset nf.t.stats

--- a/lib/netif.ml
+++ b/lib/netif.ml
@@ -936,7 +936,7 @@ module Make(C: S.CONFIGURATION) = struct
     let grant_share =
       if elapsed_ns > 0L then Int64.to_float c.grant_ns /. Int64.to_float elapsed_ns
       else 0.0 in
-    Log.info (fun f -> f
+    Log.debug (fun f -> f
       "[%s] counters: polls=%d rx_frames=%d frags/frame=%.2f frames/poll=%.2f \
        rx_dropped=%d tx_frames=%d tx_frags/frame=%.2f free_pages=%d \
        ops/s=%.0f grant_ops=%d grant_us/op=%.2f grant_share=%.1f%% \

--- a/lib/netif.ml
+++ b/lib/netif.ml
@@ -150,7 +150,7 @@ type t = {
    descriptor saying how. Everything that promises an oversized frame and
    everything that emits one asks this same question. *)
 let may_aggregate t =
-  (match t.tx_pool with Front _ -> false | Back _ -> true) && t.peer_accepts_gso
+  (match t.ending with Front _ -> false | Back _ -> true) && t.peer_accepts_gso
 
 let check_open t = if t.closed then raise Netback_shutdown
 
@@ -381,7 +381,7 @@ module Unified_TX_Ops = struct
         in
 
         let rec copy_to_peer offset acc_frags = function
-          | [] -> return (List.rev acc_frags)
+          | [] -> Lwt.return (List.rev acc_frags)
           | req :: rest ->
               let to_copy = min Io_page.page_size (size - offset) in
               (* One hypercall where map, copy and unmap took two plus the page
@@ -423,11 +423,13 @@ module Unified_TX_Ops = struct
               (* Each RX response carries the size of its own fragment. *)
               let resp = { RX.Response.id = req.RX.Request.id; offset = 0;
                            flags; size = resp_size; extras = [] } in
-              RX.Response.write resp slot
+              RX.Response.write resp slot;
               (match (if is_first then gso_mss else None) with
                | None -> ()
                | Some mss ->
-                   write_gso_extra t.rx_ring mss Extra.gso_type_tcpv4);
+                   write_gso_extra t.ending mss Extra.gso_type_tcpv4);
+              copy_to_peer (offset + to_copy)
+                ((frag, Lwt.return_unit) :: acc_frags) rest
         in
         copy_to_peer 0 [] reqs
 
@@ -535,11 +537,11 @@ module Unified_RX_Ops = struct
           Lwt.return_unit
         | Some (gref, page) ->
           Hashtbl.remove rx_map id;
-          Export.end_access ~release_ref:true gref >|= fun () ->
+          Xen_os.Xen.Export.end_access ~release_ref:true gref >|= fun () ->
           return_page nf page)
     | Back { tx_ring ; _ } -> (* Backend: only the slot, answered so the peer reclaims it *)
       List.iter (fun _id ->
-        let slot = Ring.Rpc.Back.(slot bring (next_res_id bring)) in
+        let slot = Ring.Rpc.Back.(slot tx_ring (next_res_id tx_ring)) in
         TX.Response.write
           { TX.Response.id = 0; status = TX.Response.NULL } slot) ids ;
       Lwt.return_unit
@@ -570,19 +572,19 @@ module Unified_RX_Ops = struct
       let copied =
         Xen_os.Xen.Import.copy_from ~domid:nf.t.peer_domid
           ~gref:(Xen_os.Xen.Gntref.of_int32 frag.Assemble.gref)
-          ~src_off:frag.Assemble.offset ~dst:scratch
+          ~src_off:frag.Assemble.offset ~dst:rx_scratch
           ~dst_off:frag.Assemble.offset ~len:frag.Assemble.size
       in
       account_grant nf.t.counters ~before ~ops:1;
       (match copied with
-        | Ok () -> read (Io_page.to_cstruct scratch)
+        | Ok () -> read (Io_page.to_cstruct rx_scratch)
         | Error _ -> ());
       (* Answer either way, so the peer can reuse the block whether or not we
          managed to read it. *)
       let slot = Ring.Rpc.Back.(slot tx_ring (next_res_id tx_ring)) in
       let status =
         match copied with Ok () -> TX.Response.OKAY | Error _ -> TX.Response.ERROR in
-      TX.Response.write {TX.Response.id = frag.Assemble.id; status} slot
+      TX.Response.write {TX.Response.id = frag.Assemble.id; status} slot;
       (match copied with
         | Error (`Msg m) -> Lwt.fail_with m
         | Ok () -> Lwt.return_unit)
@@ -829,9 +831,9 @@ module Make(C: S.CONFIGURATION) = struct
                (* Reused, so clear what fillf is about to write over. Only len
                   bytes ever reach the peer, so this is about the marshallers,
                   not about leaking. *)
-               let cs = Cstruct.sub (Io_page.to_cstruct page) 0 size in
+               let cs = Cstruct.sub (Io_page.to_cstruct tx_scratch) 0 size in
                Cstruct.memset cs 0;
-               (cs, Some page)
+               (cs, Some tx_scratch)
            | Back _ ->
                (* Larger than the scratch, which needs an MTU above 4 kB. A
                   fresh Io_page is aligned and comes zeroed. *)
@@ -903,7 +905,6 @@ module Make(C: S.CONFIGURATION) = struct
         Unified_RX_Ops.discard_fragments nf frags
       | Ok packet ->
         Lwt.catch (fun () ->
-          Lwt.async (fun () -> callback data)
           assemble_packet packet (Unified_RX_Ops.with_page nf) >>= fun data ->
           Unified_RX_Ops.release_extra_slots nf packet.Assemble.extra_ids
           >>= fun () ->

--- a/lib/netif.ml
+++ b/lib/netif.ml
@@ -369,7 +369,7 @@ module Unified_TX_Ops = struct
            Writing one more response than we consume requests is what puts the
            two streams permanently out of step. *)
         let slots_needed = if use_gso then pages_needed + 1 else pages_needed in
-        backend_get_n_grefs t rx_ring rx_grants pages_needed >>= fun reqs ->
+        backend_get_n_grefs t rx_ring rx_grants slots_needed >>= fun reqs ->
         (* The descriptor follows the first response, so the second consumed
            request is the one spent on it. *)
         let reqs =

--- a/lib/netif.mli
+++ b/lib/netif.mli
@@ -1,6 +1,12 @@
 module Make (C : S.CONFIGURATION) : sig
   include Mirage_net.S
 
+  val max_frame_size : t -> int
+  (** [max_frame_size t] is the largest [size] that {!write} will carry as a
+      single frame. It counts the ethernet header, unlike {!mtu}, and is not
+      part of [Mirage_net.S], so only a caller that knows this driver can use
+      it. *)
+
   (* For Frontend *)
   val connect : string -> t Lwt.t
 

--- a/lib/netif.mli
+++ b/lib/netif.mli
@@ -5,7 +5,8 @@ module Make (C : S.CONFIGURATION) : sig
   (** [max_frame_size t] is the largest [size] that {!write} will carry as a
       single frame. It counts the ethernet header, unlike {!mtu}, and is not
       part of [Mirage_net.S], so only a caller that knows this driver can use
-      it. *)
+      it. It exceeds the mtu only where the peer has agreed to segment for us.
+      It says nothing about receiving. *)
 
   (* For Frontend *)
   val connect : string -> t Lwt.t

--- a/lib/rX.ml
+++ b/lib/rX.ml
@@ -45,6 +45,7 @@ module Response = struct
     offset: int;
     flags: Flags.t;
     size: (int, error) result;
+    extras : Extra.t list;
   }
 
   let get_resp_id c = Cstruct.LE.get_uint16 c 0
@@ -72,7 +73,7 @@ module Response = struct
       match get_resp_status slot with
       | status when status > 0 -> Ok status
       | status -> Error status in
-    Ok { id; offset; flags; size }
+    Ok { id; offset; flags; size; extras = [] }
 
   let write t slot =
     set_resp_id slot t.id;

--- a/lib/rX.mli
+++ b/lib/rX.mli
@@ -34,6 +34,7 @@ module Response : sig
     offset: int;
     flags: Flags.t;
     size: (int, error) result;
+    extras : Extra.t list;
   }
 
   val read: Cstruct.t -> (t, string) result

--- a/lib/tX.ml
+++ b/lib/tX.ml
@@ -29,6 +29,7 @@ module Request = struct
        of that fragment. The receiver recovers the actual size of the
        first fragment by subtracting all of the other sizes. *)
     size: int;
+    extras : Extra.t list;
   }
 
   let get_req_gref c = Cstruct.LE.get_uint32 c 0
@@ -64,7 +65,7 @@ module Request = struct
     let flags = Flags.of_int (get_req_flags slot) in
     let id = get_req_id slot in
     let size = get_req_size slot in
-    Ok { gref; offset; flags; id; size }
+    Ok { gref; offset; flags; id; size; extras = [] }
 
   let flags t = t.flags
 

--- a/lib/tX.mli
+++ b/lib/tX.mli
@@ -24,6 +24,7 @@ module Request : sig
     flags: Flags.t;
     id: int;
     size: int;
+    extras : Extra.t list;
   }
 
   val write: t -> Cstruct.t -> unit

--- a/mirage-net-xen.opam
+++ b/mirage-net-xen.opam
@@ -18,7 +18,7 @@ depends: [
   "lwt" {>= "2.4.3"}
   "mirage-net" {>= "3.0.0"}
   "io-page" {>= "1.5.0"}
-  "mirage-xen" {>= "7.0.0"}
+  "mirage-xen" {>= "9.0.1"}
   "ipaddr" {>= "3.0.0"}
   "shared-memory-ring" {>="3.0.0"}
   "macaddr" {>= "5.2.0"}


### PR DESCRIPTION
Dear developers,
This PR is the second part of #117 , rebased after the merge of backend and frontend in #118. In its current version it supersedes #117.
The GSO mainly needs to deal with extra type requests. Now we also export max_frame_size because we can send frames with a size larger than the MTU with GSO :)
About testing, I got the following iperf3 values (with a firewall between an AppVM and sys-net, sys-net as the iperf3 server):
first with linux, 1 vcpu, 4GB RAM (mostly unused):
 ```bash
$ iperf3 -c 10.137.0.4 -t 10
...
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.00  sec  3.51 GBytes  3.01 Gbits/sec    0            sender
[  5]   0.00-10.01  sec  3.50 GBytes  3.01 Gbits/sec                  receiver
...
$ iperf3 -c 10.137.0.4 -t 10 -R
...
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.00  sec  6.31 GBytes  5.42 Gbits/sec  1227            sender
[  5]   0.00-10.00  sec  6.31 GBytes  5.42 Gbits/sec                  receiver
```
and with qubes-mirage-firewall, 1vcpu, 32MB RAM:
```bash
$ iperf3 -c 10.137.0.4 -t 10
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.00  sec   627 MBytes   526 Mbits/sec    0            sender
[  5]   0.00-10.01  sec   624 MBytes   523 Mbits/sec                  receiver
...
$ iperf3 -c 10.137.0.4 -t 10 -R
...
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.00  sec  3.40 GBytes  2.92 Gbits/sec  270            sender
[  5]   0.00-10.00  sec  3.39 GBytes  2.91 Gbits/sec                  receiver
```

So we are (with a very fragile test protocol ;) ) around half the performances of Linux when sys-net sends packets (e.g. for download to the AppVM), and 1/6 for the upload path.

The biggest difference between download and upload is due to the fact we don't advertise GSO on the backend side (see 38acb5b5d65d320705db4269157373e220462d32) to avoid clients sending us GSO frames. To be able to forward GSO on our frontend side, we need to skip extra info slots which our netvm consumes without writing a response into them (see https://github.com/xen-project/xen/blob/RELEASE-4.19.4/xen/include/public/io/netif.h#L883 , I always refer to Xen 4.19.4 as it's the current Xen version on Qubes, but I suppose the protocol is not broken in more recent releases) and Lwt_ring.Front does not allow skipping slots yet (maybe it's worth writing a PR for that). Although I don't know how much we will gain here, as even linux is not symmetrical and that can be improved later :).

Then it is possible to gain a bit more bandwidth by vectorising the hypercalls for the page copies between domains, the hypervisor already taking an array of operations for a single GNTTABOP_copy. And that will be another mirage-xen story before anything happen here.